### PR TITLE
fix #15

### DIFF
--- a/combiner/lists/TeX-AMS_CHTML-full.lis
+++ b/combiner/lists/TeX-AMS_CHTML-full.lis
@@ -6,6 +6,8 @@ extensions/MathZoom.js
 extensions/MathMenu.js
 jax/element/mml/jax.js
 extensions/toMathML.js
+extensions/TeX/noErrors.js
+extensions/TeX/noUndefined.js
 jax/input/TeX/jax.js
 extensions/TeX/AMSmath.js
 extensions/TeX/AMSsymbols.js

--- a/combiner/lists/TeX-AMS_CHTML.lis
+++ b/combiner/lists/TeX-AMS_CHTML.lis
@@ -6,6 +6,8 @@ extensions/MathZoom.js
 extensions/MathMenu.js
 jax/element/mml/jax.js
 extensions/toMathML.js
+extensions/TeX/noErrors.js
+extensions/TeX/noUndefined.js
 jax/input/TeX/jax.js
 extensions/TeX/AMSmath.js
 extensions/TeX/AMSsymbols.js

--- a/combiner/lists/TeX-AMS_SVG-full.lis
+++ b/combiner/lists/TeX-AMS_SVG-full.lis
@@ -7,6 +7,8 @@ extensions/MathZoom.js
 extensions/MathMenu.js
 jax/element/mml/jax.js
 extensions/toMathML.js
+extensions/TeX/noErrors.js
+extensions/TeX/noUndefined.js
 jax/input/TeX/jax.js
 extensions/TeX/AMSmath.js
 extensions/TeX/AMSsymbols.js

--- a/combiner/lists/TeX-AMS_SVG.lis
+++ b/combiner/lists/TeX-AMS_SVG.lis
@@ -7,6 +7,8 @@ extensions/MathZoom.js
 extensions/MathMenu.js
 jax/element/mml/jax.js
 extensions/toMathML.js
+extensions/TeX/noErrors.js
+extensions/TeX/noUndefined.js
 jax/input/TeX/jax.js
 extensions/TeX/AMSmath.js
 extensions/TeX/AMSsymbols.js


### PR DESCRIPTION
add noErrors and noUndefined extensions to the TeX-AMS_SVG (-full) and TeX-AMS_CHTML (-full) combined configuration lists.