### PR TITLE
Base extended latin

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -31,6 +31,7 @@ SFNT2WOFF=sfnt2woff
 TTF2EOT=ttf2eot
 TTF2SVG=/usr/share/java/batik-ttf2svg.jar
 TTX=ttx
+WOFF2=woff2_compress
 
 #### Image compression tools ####
 OPTIPNG=optipng

--- a/default.cfg
+++ b/default.cfg
@@ -32,6 +32,7 @@ TTF2EOT=ttf2eot
 TTF2SVG=/usr/share/java/batik-ttf2svg.jar
 TTX=ttx
 WOFF2=woff2_compress
+TTFAUTOHINT=ttfautohint
 
 #### Image compression tools ####
 OPTIPNG=optipng

--- a/default.cfg
+++ b/default.cfg
@@ -37,8 +37,8 @@ OPTIPNG=optipng
 ADVPNG=advpng
 
 ##### TeXLive Encoding
-TETEXENCODING=/usr/share/texmf-texlive/fonts/enc/dvips/tetex/
-BASEENCODING=/usr/share/texmf-texlive/fonts/enc/dvips/base/
+TETEXENCODING=/usr/share/texlive/texmf-texlive/fonts/enc/dvips/tetex/
+BASEENCODING=/usr/share/texlive/texmf-texlive/fonts/enc/dvips/base/
 
 ##### packer #####
 YUICOMPRESSOR=/usr/share/yui-compressor/yui-compressor.jar

--- a/fonts/OTF/TeX/.gitignore
+++ b/fonts/OTF/TeX/.gitignore
@@ -8,3 +8,4 @@ pfa
 svg
 ttf
 woff
+woff2

--- a/fonts/OTF/TeX/Makefile
+++ b/fonts/OTF/TeX/Makefile
@@ -142,6 +142,17 @@ woff: otf ttf
 	mv ttf/*.woff woff
 	rm -f woff/*WinChrom* woff/*WinIE6* woff/*Greek*
 
+woff2: woff
+	@for file in `ls ttf/*.ttf | $(SED) 's|ttf/\(.*\)\.ttf|\1|'`; do \
+		echo "Generating $$file.woff2..."; \
+		$(WOFF2) ttf/$$file.ttf; \
+		done
+
+	mkdir -p woff2
+	rm -f woff2/*
+	mv ttf/*.woff2 woff2
+	rm -f woff2/*WinChrom* woff2/*WinIE6* woff2/*Greek*
+
 css: woff
 	mkdir -p css
 	rm -f css/*

--- a/fonts/OTF/TeX/Makefile
+++ b/fonts/OTF/TeX/Makefile
@@ -132,14 +132,14 @@ svg: ttf
 	rm -f svg/*WinIE6* svg/*Greek*
 
 woff: otf ttf
-	@for file in `ls otf/*.otf | $(SED) 's|otf/\(.*\)\.otf|\1|'`; do \
+	@for file in `ls ttf/*.ttf | $(SED) 's|ttf/\(.*\)\.ttf|\1|'`; do \
 		echo "Generating $$file.woff..."; \
-		$(SFNT2WOFF) otf/$$file.otf; \
+		$(SFNT2WOFF) ttf/$$file.ttf; \
 		done
 
 	mkdir -p woff
 	rm -f woff/*
-	mv otf/*.woff woff
+	mv ttf/*.woff woff
 	rm -f woff/*WinChrom* woff/*WinIE6* woff/*Greek*
 
 css: woff

--- a/fonts/OTF/TeX/Makefile
+++ b/fonts/OTF/TeX/Makefile
@@ -106,6 +106,8 @@ ttf: ff
 		echo $$file; \
 		$(FONTFORGE) -lang=ff -script ff/$$file; \
 		done
+
+	./fix_os2_metrics.rb ttf/
 eot: ttf
 	mkdir -p eot
 	rm -f eot/*

--- a/fonts/OTF/TeX/Makefile
+++ b/fonts/OTF/TeX/Makefile
@@ -97,11 +97,11 @@ ttf: ff
 	mkdir -p ttf
 	rm -f ttf/*
 
-        # Handle the MathJax_Size4 font first as it used by other fonts.
-	@echo "MathJax_Size4.ff"
-	$(FONTFORGE) -lang=ff -script ff/MathJax_Size4.ff
+        # Handle the KaTeX_Size4 font first as it used by other fonts.
+	@echo "KaTeX_Size4.ff"
+	$(FONTFORGE) -lang=ff -script ff/KaTeX_Size4.ff
 
-	@for file in `cd ff; ls *.ff | $(GREP) -v MathJax_Size4`; do \
+	@for file in `cd ff; ls *.ff | $(GREP) -v KaTeX_Size4`; do \
 		echo ""; \
 		echo $$file; \
 		$(FONTFORGE) -lang=ff -script ff/$$file; \
@@ -149,8 +149,8 @@ css: woff
 		$(PERL) woff2css $$file > css/$$file.css; \
 		end
 
-	$(PERL) css2all css/*.css > MathJax-All.css
-	mv MathJax-All.css css
+	$(PERL) css2all css/*.css > KaTeX-All.css
+	mv KaTeX-All.css css
 
 OTFandTTF: ttf
 
@@ -158,12 +158,12 @@ fonts: OTFandTTF eot svg woff # css
 
 install:
         #Copy the font files into the system font directory
-        #rm -f $FONTDIR/MathJax_*
+        #rm -f $FONTDIR/KaTeX_*
 	cp `ls otf/*.otf | $(GREP) -v 'Greek'` $(FONTDIR)
         # echo `ls ttf/*.ttf | $(GREP) -Ev 'WinChro|WinIE6'`
 	cp ttf/*Greek*.ttf $(FONTDIR)
 
-        #  Put the fonts into the MathJax fonts folder
+        #  Put the fonts into the KaTeX fonts folder
 	rm -f $(MATHJAXDIR)/fonts/HTML-CSS/TeX/otf/*.*
 	rm -f $(MATHJAXDIR)/fonts/HTML-CSS/TeX/eot/*.*
 	rm -f $(MATHJAXDIR)/fonts/HTML-CSS/TeX/svg/*.*

--- a/fonts/OTF/TeX/Makefile
+++ b/fonts/OTF/TeX/Makefile
@@ -107,6 +107,16 @@ ttf: ff
 		$(FONTFORGE) -lang=ff -script ff/$$file; \
 		done
 
+	@for file in `ls ttf/*.ttf`; do \
+		echo "hinting $$file"; \
+		if echo "$$file" | $(GREP) -q -e "Greek" -e "Size[1-4]" -e "Typewriter" -e "Win"; then \
+			$(TTFAUTOHINT) --windows-compatibility --symbol $$file $$file.hinted; \
+		else \
+			$(TTFAUTOHINT) --windows-compatibility $$file $$file.hinted; \
+		fi; \
+		mv $$file.hinted $$file; \
+		done
+
 	./fix_os2_metrics.rb ttf/
 eot: ttf
 	mkdir -p eot

--- a/fonts/OTF/TeX/fix_os2_metrics.rb
+++ b/fonts/OTF/TeX/fix_os2_metrics.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'rubygems'
+require 'ttfunk'
+
+def metrics_for_file(filename)
+  file = TTFunk::File.open(filename)
+
+  max_height = 0
+  max_depth = 0
+
+  file.cmap.unicode[0].code_map.sort.each do |u, g|
+    glyph = file.glyph_outlines.for(g)
+    if glyph
+      max_height = [max_height, glyph.y_max].max
+      max_depth = [-glyph.y_min, max_depth].max
+    end
+
+  end
+
+  return [max_height, max_depth]
+end
+
+if ARGV.length < 1
+  puts "Usage: %s <directory of fonts>" % $0
+  exit(false)
+end
+
+font_dir = File.join(File.dirname(__FILE__), ARGV[0])
+glob = File.join(font_dir, "*.ttf")
+
+Dir.glob(glob).each do |file_name|
+  ascent, descent = metrics_for_file(file_name)
+
+  `./modify_ascent_descent.py #{file_name} #{ascent} #{descent}`
+end
+

--- a/fonts/OTF/TeX/fix_os2_metrics.rb
+++ b/fonts/OTF/TeX/fix_os2_metrics.rb
@@ -33,6 +33,6 @@ glob = File.join(font_dir, "*.ttf")
 Dir.glob(glob).each do |file_name|
   ascent, descent = metrics_for_file(file_name)
 
-  `./modify_ascent_descent.py #{file_name} #{ascent} #{descent}`
+  system("./modify_ascent_descent.py", file_name, ascent.to_s, descent.to_s)
 end
 

--- a/fonts/OTF/TeX/lib/Space.ttx
+++ b/fonts/OTF/TeX/lib/Space.ttx
@@ -109,7 +109,7 @@
 
   <name>
     <namerecord nameID="0" platformID="1" platEncID="0" langID="0x0">
-      Copyright (c) 2009-2010 Design Science, Inc.
+      Copyright (c) 2009-2010 Design Science, Inc.&#10;Copyright (c) 2014 Khan Academy
     </namerecord>
     <namerecord nameID="1" platformID="1" platEncID="0" langID="0x0">
       *NAME*
@@ -130,7 +130,7 @@
       *NAME*-*WEIGHT*
     </namerecord>
     <namerecord nameID="13" platformID="1" platEncID="0" langID="0x0">
-      Copyright (c) 2009-2010, Design Science, Inc. (&lt;www.mathjax.org>),&#10;with Reserved Font Name *NAME*.&#10;&#10;This Font Software is licensed under the SIL Open Font License, Version 1.1.&#10;This license available with a FAQ at:&#10;http://scripts.sil.org/OFL
+      Copyright (c) 2009-2010, Design Science, Inc. (&lt;www.mathjax.org>)&#10;Copyright (c) 2014 Khan Academy (&lt;www.khanacademy.org>),&#10;with Reserved Font Name *NAME*.&#10;&#10;This Font Software is licensed under the SIL Open Font License, Version 1.1.&#10;This license available with a FAQ at:&#10;http://scripts.sil.org/OFL
     </namerecord>
     <namerecord nameID="14" platformID="1" platEncID="0" langID="0x0">
       http://scripts.sil.org/OFL
@@ -142,7 +142,7 @@
       *WEIGHT*
     </namerecord>
     <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
-      Copyright (c) 2009-2010 Design Science, Inc.
+      Copyright (c) 2009-2010 Design Science, Inc.&#10;Copyright (c) 2014 Khan Academy
     </namerecord>
     <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
       *NAME*
@@ -163,7 +163,7 @@
       *NAME*-*WEIGHT*
     </namerecord>
     <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
-      Copyright (c) 2009-2010, Design Science, Inc. (&lt;www.mathjax.org>),&#10;with Reserved Font Name *NAME*.&#10;&#10;This Font Software is licensed under the SIL Open Font License, Version 1.1.&#10;This license available with a FAQ at:&#10;http://scripts.sil.org/OFL
+      Copyright (c) 2009-2010, Design Science, Inc. (&lt;www.mathjax.org>)&#10;Copyright (c) 2014 Khan Academy (&lt;www.khanacademy.org>),&#10;with Reserved Font Name *NAME*.&#10;&#10;This Font Software is licensed under the SIL Open Font License, Version 1.1.&#10;This license available with a FAQ at:&#10;http://scripts.sil.org/OFL
     </namerecord>
     <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
       http://scripts.sil.org/OFL
@@ -460,7 +460,7 @@
 
     <CFFFont name="*NAME*-*WEIGHT*">
       <version value="001.001"/>
-      <Notice value="Copyright (c) 2009-2010 Design Science, Inc."/>
+      <Notice value="Copyright (c) 2009-2010 Design Science, Inc., Copyright (c) 2014 Khan Academy"/>
       <FullName value="*NAME*-*WEIGHT*"/>
       <FamilyName value="*NAME*"/>
       <Weight value="*NORMAL*"/>

--- a/fonts/OTF/TeX/makeFF
+++ b/fonts/OTF/TeX/makeFF
@@ -66,6 +66,13 @@ $map{cmr10} = {
     0x7E => [0x303,-500,0], # \tilde (combining)
     0x7F => 0xA8,           # \ddot
     0x7F => [0x308,-500,0], # \ddot (combining)
+    0x19 => 0xDF,           # sharp S
+    0x1A => 0xE6,           # ae ligature
+    0x1B => 0x153,          # oe ligature
+    0x1C => 0xF8,           # o with slash
+    0x1D => 0xC6,           # AE ligature
+    0x1E => 0x152,          # OE ligature
+    0x1F => 0xD8,           # O with slash         
   ],
 
   "Greek" => [

--- a/fonts/OTF/TeX/makeFF
+++ b/fonts/OTF/TeX/makeFF
@@ -1,7 +1,7 @@
 #! /usr/bin/perl
 
 #  Creates the FontForge files needed to create the
-#  MathJax fonts from the TeX source files, constructing some
+#  KaTeX fonts from the TeX source files, constructing some
 #  glyphs from two or more parts, when needed.
 #
 #  Usage:  ./makeFF
@@ -1704,10 +1704,10 @@ $extra{'Main-Regular'} = {
   mapsto => [
     'Select(0u2192)','Copy()',
     'Select(0u21A6)','Paste()',
-    'Generate("otf/MathJax_Main-Regular.otf")',
+    'Generate("otf/KaTeX_Main-Regular.otf")',
     'Open("pfa/cmsy10.pfa")',
     'Select(0x37)','Copy()',
-    'Open("otf/MathJax_Main-Regular.otf")',
+    'Open("otf/KaTeX_Main-Regular.otf")',
     'Select(0u21A6)',
     'PasteWithOffset(0,0)',
     'RemoveOverlap()','Simplify()',
@@ -1716,10 +1716,10 @@ $extra{'Main-Regular'} = {
   xlongmapsto => [
     'Select(0u27F6)','Copy()',
     'Select(0u27FC)','Paste()',
-    'Generate("otf/MathJax_Main-Regular.otf")',
+    'Generate("otf/KaTeX_Main-Regular.otf")',
     'Open("pfa/cmsy10.pfa")',
     'Select(0x37)','Copy()',
-    'Open("otf/MathJax_Main-Regular.otf")',
+    'Open("otf/KaTeX_Main-Regular.otf")',
     'Select(0u27FC)',
     'PasteWithOffset(0,0)',
     'RemoveOverlap()','Simplify()',
@@ -1728,10 +1728,10 @@ $extra{'Main-Regular'} = {
   hookleftarrow => [
     'Select(0u2190)','Copy()',
     'Select(0u21A9)','Paste()',
-    'Generate("otf/MathJax_Main-Regular.otf")',
+    'Generate("otf/KaTeX_Main-Regular.otf")',
     'Open("pfa/cmmi10.pfa")',
     'Select(0x2D)','Copy()',
-    'Open("otf/MathJax_Main-Regular.otf")',
+    'Open("otf/KaTeX_Main-Regular.otf")',
     'Select(0u21A9)',
     'PasteWithOffset(848,0)',
     'SetRBearing(126,1)',
@@ -1739,10 +1739,10 @@ $extra{'Main-Regular'} = {
   ],
 
   hookrightarrow => [
-    'Generate("otf/MathJax_Main-Regular.otf")',
+    'Generate("otf/KaTeX_Main-Regular.otf")',
     'Open("pfa/cmmi10.pfa")',
     'Select(0x2C)','Copy()',
-    'Open("otf/MathJax_Main-Regular.otf")',
+    'Open("otf/KaTeX_Main-Regular.otf")',
     'Select(0u21AA)','Paste()',
     'Select(0u2192)','Copy()',
     'Select(0u21AA)',
@@ -1761,8 +1761,8 @@ $extra{'Main-Regular'} = {
   ],
 
   lgroup => [
-    'Generate("otf/MathJax_Main-Regular.otf")',
-    'Open("otf/MathJax_Size4-Regular.otf")',
+    'Generate("otf/KaTeX_Main-Regular.otf")',
+    'Open("otf/KaTeX_Size4-Regular.otf")',
     'Select(0u23A7)','Copy()',
     'Select(0u23B8)','Paste()',
     'Select(0u23A9)','Copy()',
@@ -1772,13 +1772,13 @@ $extra{'Main-Regular'} = {
     'RemoveOverlap()','Simplify()',
     'SetRBearing(-38,1)',
     'Copy()','Clear()',
-    'Open("otf/MathJax_Main-Regular.otf")',
+    'Open("otf/KaTeX_Main-Regular.otf")',
     'Select(0u27EE)','Paste()',
   ],
 
   rgroup => [
-    'Generate("otf/MathJax_Main-Regular.otf")',
-    'Open("otf/MathJax_Size4-Regular.otf")',
+    'Generate("otf/KaTeX_Main-Regular.otf")',
+    'Open("otf/KaTeX_Size4-Regular.otf")',
     'Select(0u23AB)','Copy()',
     'Select(0u23B8)','Paste()',
     'Select(0u23AD)','Copy()',
@@ -1788,13 +1788,13 @@ $extra{'Main-Regular'} = {
     'RemoveOverlap()','Simplify()',
     'SetRBearing(-38,1)',
     'Copy()','Clear()',
-    'Open("otf/MathJax_Main-Regular.otf")',
+    'Open("otf/KaTeX_Main-Regular.otf")',
     'Select(0u27EF)','Paste()',
   ],
 
   lmoustache => [
-    'Generate("otf/MathJax_Main-Regular.otf")',
-    'Open("otf/MathJax_Size4-Regular.otf")',
+    'Generate("otf/KaTeX_Main-Regular.otf")',
+    'Open("otf/KaTeX_Size4-Regular.otf")',
     'Select(0u23A7)','Copy()',
     'Select(0u23B8)','Paste()',
     'Select(0u23AD)','Copy()',
@@ -1804,13 +1804,13 @@ $extra{'Main-Regular'} = {
     'RemoveOverlap()','Simplify()',
     'SetRBearing(-38,1)',
     'Copy()','Clear()',
-    'Open("otf/MathJax_Main-Regular.otf")',
+    'Open("otf/KaTeX_Main-Regular.otf")',
     'Select(0u23B0)','Paste()',
   ],
 
   rmoustache => [
-    'Generate("otf/MathJax_Main-Regular.otf")',
-    'Open("otf/MathJax_Size4-Regular.otf")',
+    'Generate("otf/KaTeX_Main-Regular.otf")',
+    'Open("otf/KaTeX_Size4-Regular.otf")',
     'Select(0u23AB)','Copy()',
     'Select(0u23B8)','Paste()',
     'Select(0u23A9)','Copy()',
@@ -1820,7 +1820,7 @@ $extra{'Main-Regular'} = {
     'RemoveOverlap()','Simplify()',
     'SetRBearing(-38,1)',
     'Copy()','Clear()',
-    'Open("otf/MathJax_Main-Regular.otf")',
+    'Open("otf/KaTeX_Main-Regular.otf")',
     'Select(0u23B1)','Paste()',
   ],
 
@@ -2030,10 +2030,10 @@ $extra{'Main-Bold'} = {
   mapsto => [
     'Select(0u2192)','Copy()',
     'Select(0u21A6)','Paste()',
-    'Generate("otf/MathJax_Main-Bold.otf")',
+    'Generate("otf/KaTeX_Main-Bold.otf")',
     'Open("pfa/cmbsy10.pfa")',
     'Select(0x37)','Copy()',
-    'Open("otf/MathJax_Main-Bold.otf")',
+    'Open("otf/KaTeX_Main-Bold.otf")',
     'Select(0u21A6)',
     'PasteWithOffset(0,0)',
     'RemoveOverlap()','Simplify()',
@@ -2042,10 +2042,10 @@ $extra{'Main-Bold'} = {
   xlongmapsto => [
     'Select(0u27F6)','Copy()',
     'Select(0u27FC)','Paste()',
-    'Generate("otf/MathJax_Main-Bold.otf")',
+    'Generate("otf/KaTeX_Main-Bold.otf")',
     'Open("pfa/cmbsy10.pfa")',
     'Select(0x37)','Copy()',
-    'Open("otf/MathJax_Main-Bold.otf")',
+    'Open("otf/KaTeX_Main-Bold.otf")',
     'Select(0u27FC)',
     'PasteWithOffset(0,0)',
     'RemoveOverlap()','Simplify()',
@@ -2054,10 +2054,10 @@ $extra{'Main-Bold'} = {
   hookleftarrow => [
     'Select(0u2190)','Copy()',
     'Select(0u21A9)','Paste()',
-    'Generate("otf/MathJax_Main-Bold.otf")',
+    'Generate("otf/KaTeX_Main-Bold.otf")',
     'Open("pfa/cmmib10.pfa")',
     'Select(0x2D)','Copy()',
-    'Open("otf/MathJax_Main-Bold.otf")',
+    'Open("otf/KaTeX_Main-Bold.otf")',
     'Select(0u21A9)',
     'PasteWithOffset(965,0)',
     'SetRBearing(132,1)',
@@ -2065,10 +2065,10 @@ $extra{'Main-Bold'} = {
   ],
 
   hookrightarrow => [
-    'Generate("otf/MathJax_Main-Bold.otf")',
+    'Generate("otf/KaTeX_Main-Bold.otf")',
     'Open("pfa/cmmib10.pfa")',
     'Select(0x2C)','Copy()',
-    'Open("otf/MathJax_Main-Bold.otf")',
+    'Open("otf/KaTeX_Main-Bold.otf")',
     'Select(0u21AA)','Paste()',
     'Select(0u2192)','Copy()',
     'Select(0u21AA)',
@@ -2170,7 +2170,7 @@ $extra{'Size4'} = {
   braceext => [
     'Open("lib/Extra.otf")',
     'Select(0u5F)','Copy()',
-    'Open("otf/MathJax_Size4-Regular.otf")',
+    'Open("otf/KaTeX_Size4-Regular.otf")',
     'Select(0uE154)','Paste()',
   ],
 };
@@ -2219,26 +2219,26 @@ $extra{"SansSerif-Bold"} = {
 
 $extra{"WinIE6"} = {
   neq => [
-    'Generate("otf/MathJax_WinIE6-Regular.otf")',
-    'Open("otf/MathJax_Main-Regular.otf")',
+    'Generate("otf/KaTeX_WinIE6-Regular.otf")',
+    'Open("otf/KaTeX_Main-Regular.otf")',
     'Select(0u2260)','Copy()',
-    'Open("otf/MathJax_WinIE6-Regular.otf")',
+    'Open("otf/KaTeX_WinIE6-Regular.otf")',
     'Select(0uE220)','Paste()'
   ],
 
   neq_bold => [
-    'Generate("otf/MathJax_WinIE6-Regular.otf")',
-    'Open("otf/MathJax_Main-Bold.otf")',
+    'Generate("otf/KaTeX_WinIE6-Regular.otf")',
+    'Open("otf/KaTeX_Main-Bold.otf")',
     'Select(0u2260)','Copy()',
-    'Open("otf/MathJax_WinIE6-Regular.otf")',
+    'Open("otf/KaTeX_WinIE6-Regular.otf")',
     'Select(0uE260)','Paste()'
   ],
 
   angle_bold => [
-    'Generate("otf/MathJax_WinIE6-Regular.otf")',
-    'Open("otf/MathJax_Main-Bold.otf")',
+    'Generate("otf/KaTeX_WinIE6-Regular.otf")',
+    'Open("otf/KaTeX_Main-Bold.otf")',
     'Select(0u2220)','Copy()',
-    'Open("otf/MathJax_WinIE6-Regular.otf")',
+    'Open("otf/KaTeX_WinIE6-Regular.otf")',
     'Select(0uE256)','Paste()'
   ]
 };
@@ -2296,7 +2296,7 @@ sub checkSkew {
 foreach $cmfont (sort (keys %map)) {
   print "Reading $cmfont...\n";
   foreach $mjfont (keys %{$map{$cmfont}}) {
-    $fontname = "MathJax_$mjfont";
+    $fontname = "KaTeX_$mjfont";
     $style = $fontname; $style =~ s/.*?(-|$)//; $style = "Regular" unless $style;
     $normal = "Normal"; $normal = "Bold" if style =~ m/Bold/;
     $family = $fontname; $family =~ s/-.*//;
@@ -2367,15 +2367,15 @@ foreach $font (keys %extra) {
 foreach $font (sort keys %script) {
   $family = $font; $family .= "-Regular" unless $family =~ m/-/;
   $style = $family; $style =~ s/.*-//;
-  print "MathJax_$font\n";
-  open(SCRIPT,">","ff/MathJax_$font.ff");
+  print "KaTeX_$font\n";
+  open(SCRIPT,">","ff/KaTeX_$font.ff");
   print SCRIPT join(";\n",@{$script{$font}},@{$style{$style}},"",
                     'SelectAll()','RoundToInt()',
 		    'Simplify()','AddExtrema()','Simplify()',
 		    'ClearHints()','AutoHint()','RoundToInt()',
-		    'Generate("otf/MathJax_'.$family.'.otf")',
+		    'Generate("otf/KaTeX_'.$family.'.otf")',
 		    'SelectAll()','AutoInstr()',
-                    'Generate("ttf/MathJax_'.$family.'.ttf")'),"\n";
+                    'Generate("ttf/KaTeX_'.$family.'.ttf")'),"\n";
   close(SCRIPT);
 }
 
@@ -2385,7 +2385,7 @@ foreach $font (sort keys %script) {
 open(SKEWFILE,">skew.js");
 foreach $mjfont (sort(keys %SKEW)) {
   next if $mjfont eq "Math-Regular";
-  $name = "MathJax_$mjfont";
+  $name = "KaTeX_$mjfont";
   $name =~ s/-Regular//; $name =~ s/BoldItalic/Bold-Italic/;
   $name =~ s/-I/-i/; $name =~ s/-B/-b/;
   print SKEWFILE "  HTMLCSS.FONTDATA.FONTS['$name'].skew = {";

--- a/fonts/OTF/TeX/makeFF
+++ b/fonts/OTF/TeX/makeFF
@@ -2309,7 +2309,7 @@ foreach $cmfont (sort (keys %map)) {
       $lines =~ s/\*WEIGHT_S\*/$STYLE/g; $lines =~ s/\*NORMAL\*/$normal/g;
       if ($style eq "Regular") {$lines =~ s/\* WEIGHT\*//g} else {$lines =~ s/\* WEIGHT\*/ $STYLE/g}
       open(SPACE,">Space.ttx"); print SPACE $lines; close(SPACE);
-      `$TTX Space.ttx; mv Space.otf '$otf'`; unlink("Space.ttx");
+      `$TTX Space.ttx; mv Space.ttf '$otf'`; unlink("Space.ttx");
       $script{$mjfont} = [
         'Open("'.$otf.'")',
         'SetPanose([0,0,'.($style eq 'Bold' ? '8' : '0').',0,0,0,0,0,0,0])',

--- a/fonts/OTF/TeX/modify_ascent_descent.py
+++ b/fonts/OTF/TeX/modify_ascent_descent.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python2
+
+import fontforge
+
+import sys
+
+if len(sys.argv) < 4:
+    print "Usage: %s <font file> <ascent> <descent>" % sys.argv[0]
+    sys.exit(1)
+
+font_file = sys.argv[1]
+ascent = int(sys.argv[2])
+descent = int(sys.argv[3])
+
+font = fontforge.open(font_file)
+
+font.os2_winascent = ascent
+font.os2_windescent = descent
+
+font.hhea_ascent = ascent
+font.hhea_descent = -descent
+
+font.generate(font_file, flags=("TeX-table"))

--- a/fonts/OTF/TeX/woff2css
+++ b/fonts/OTF/TeX/woff2css
@@ -27,6 +27,7 @@ print " *\n";
 print " *  MathJax/fonts/HTML-CSS/TeX/css/$name.css\n";
 print " *  \n";
 print " *  Copyright (c) 2011 by Design Science, Inc.\n";
+print " *  Copyright (c) 2014 by Khan Academy\n";
 print " *\n";
 print " *  Licensed under the Apache License, Version 2.0 (the \"License\");\n";
 print " *  you may not use this file except in compliance with the License.\n";


### PR DESCRIPTION
We'd like to support rendering extended latin characters in
order to support rendering text from European languages within
\text{}.  Adding the base characters to Main-Regular, Main-Italic,
and Main-Bold, is the first step in doing so.  Eventually we'll
need a way to compose accented characted from unicode text, but
that will follow in a later diff.
    
Test Plan:
    - run `make ttf eot woff woff2` in the MathJaxFonts docker image in KaTeX
    - copy the font files out of the docker, open them up on Font Book and verify that they have the correct glyphs at the correct unicode code points
    
Reviewers: emily
