### PR TITLE
Make v3-lab work with IE11

### DIFF
--- a/lib/v3-lab.js
+++ b/lib/v3-lab.js
@@ -105,7 +105,10 @@ window.MathJax = {
         source: source,
         require: (url) => System.import(url)
     },
-    options: {},
+    options: {
+        compileError(doc, math, err) {console.log(err); throw err},
+        typesetError(doc, math, err) {console.log(err); throw err}
+    },
     startup: {
         input: ['tex', 'mml'],
         output: 'chtml',

--- a/lib/v3-lab.js
+++ b/lib/v3-lab.js
@@ -29,8 +29,6 @@ import '../node_modules/mj-context-menu/dist/context_menu.js';
 
 import {TeX} from '../mathjax3/js/input/tex.js';
 import {ConfigurationHandler} from '../mathjax3/js/input/tex/Configuration.js';
-import {MenuHandler} from '../mathjax3/js/ui/menu/MenuHandler.js';
-import {Menu} from '../mathjax3/js/ui/menu/Menu.js';
 import {STATE} from '../mathjax3/js/core/MathItem.js';
 
 import {source} from '../mathjax3/components/src/source.js';
@@ -97,7 +95,8 @@ window.MathJax = {
         load: [
             'input/tex-full',
             'input/mml',
-            'output/chtml'
+            'output/chtml',
+            'ui/menu',
         ],
         paths: {
             mathjax: './mathjax3/es5'
@@ -549,7 +548,6 @@ const Lab = window.Lab = {
      * @param {Handler} handler   The handler to be augmented
      */
     menuHandler(handler) {
-        handler = MenuHandler(handler);
         handler.documentClass = V3DocumentMixin(handler.documentClass);
         return handler;
     },

--- a/v3-lab.html
+++ b/v3-lab.html
@@ -1,7 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset="utf-8" />
+<meta http-equiv="x-ua-compatible" content="ie=edge">
 <title>MathJax v3 Interactive Lab</title>
+<!--[if IE 11]>
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<![endif]-->
 <script src="lib/traceur.min.js"></script>
 <script src="lib/system.js"></script>
 <style>
@@ -73,7 +78,7 @@ body {
 }
 #package {
   margin-top: .5em;
-  white-space: initial ! important;
+  white-space: normal ! important;
 }
 #package > span > span {
   display: inline-block;
@@ -141,8 +146,12 @@ input[disabled] + label {
 </div>
 
 <script>
+__dirname = String(location.href).replace(/v3-lab.html.*/, 'mathjax3/components/src');
+</script>
+
+<script>
 System.import('./lib/v3-lab.js')
-  .then(() => System.import('./mathjax3/components/src/startup/startup.js'))
+  .then(function () {return System.import('./mathjax3/components/src/startup/startup.js')})
   .catch(function (error) {console.log(error.message)});
 </script>
 </body>

--- a/v3-lab.html
+++ b/v3-lab.html
@@ -146,7 +146,7 @@ input[disabled] + label {
 </div>
 
 <script>
-__dirname = String(location.href).replace(/v3-lab.html.*/, 'mathjax3/components/src');
+__dirname = String(location.href).replace(/v3-lab\.html.*/, 'mathjax3/components/src');
 </script>
 
 <script>


### PR DESCRIPTION
This PR dumbs down some javascript and css, and includes polyfill and other code needed for IE11.  It also adds better error reporting in the compile and typeset functions.