### PR TITLE
Update lab for use with new mj-context-menu code

### DIFF
--- a/lib/v3-lab.js
+++ b/lib/v3-lab.js
@@ -22,10 +22,7 @@
  */
 
 
-import {MathJax as mathjax} from '../mathjax3/js/mathjax.js';
 import '../mathjax3/js/util/asyncLoad/system.js';
-
-import '../node_modules/mj-context-menu/dist/context_menu.js';
 
 import {TeX} from '../mathjax3/js/input/tex.js';
 import {ConfigurationHandler} from '../mathjax3/js/input/tex/Configuration.js';
@@ -96,17 +93,18 @@ window.MathJax = {
             'input/tex-full',
             'input/mml',
             'output/chtml',
-            'ui/menu',
+            'ui/menu'
         ],
         paths: {
             mathjax: './mathjax3/es5'
         },
         source: source,
+        failed: (err) => console.log(err),
         require: (url) => System.import(url)
     },
     options: {
-        compileError(doc, math, err) {console.log(err); throw err},
-        typesetError(doc, math, err) {console.log(err); throw err}
+        compileError(doc, math, err) {console.log(err); return doc.compileError(math, err)},
+        typesetError(doc, math, err) {console.log(err); return doc.typesetError(math, err)}
     },
     startup: {
         input: ['tex', 'mml'],
@@ -295,7 +293,8 @@ const Lab = window.Lab = {
      *   using the new set of packages.
      */
     newPackages() {
-        this.jax.TeX = new TeX({packages: this.getPackages()});
+        MathJax.config.tex.packages = this.getPackages();
+        this.jax.TeX = new TeX(MathJax.config.tex);
         this.jax.TeX.setAdaptor(this.doc.adaptor);
         this.jax.TeX.setMmlFactory(this.doc.mmlFactory);
         if (this.format === 'TeX') {
@@ -517,7 +516,7 @@ const Lab = window.Lab = {
      * @param {string} name    The name of the variable to get
      */
     menuVariable(name) {
-        return this.doc.menu.menu.getPool().lookup(name);
+        return this.doc.menu.menu.pool.lookup(name);
     },
 
     /**

--- a/v3-lab.html
+++ b/v3-lab.html
@@ -9,6 +9,13 @@
 <![endif]-->
 <script src="lib/traceur.min.js"></script>
 <script src="lib/system.js"></script>
+<script>
+System.config({
+  map: {
+    'mj-context-menu': './node_modules/mj-context-menu'
+  }
+});
+</script>
 <style>
 h1 {
   margin-left: 1.5em;


### PR DESCRIPTION
This PR fixes the lab to use the new context menu code.

You will also need to make a change to the `MathJax-src/components/src/ui/menu/menu.js` file to remove the first line (that imports `context-menu.js`, which is no longer needed.

The main issue was the change in the `tsconfig` for MathJax-src to add a path for the `mj-context-menu` package.  That is only known to Typescript, not to System.js, which is what is loading the source files into the lab.  So I've added a corresponding mapping within the `v3-lab.html` file to tell System.js where to find the context menu.

The other important change is to replace `getPool()` with `pool`.  The rest of the changes are to remove unneeded imports and improve the error processing.