### PR TITLE
Updates to lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ nmp install mj-context-menu
 
 Create a symbolic link for the context menu. MathJax expects it to be _in parallel_ to its code.
 
-``` sheel
+``` shell
 ln -s node_modules/mj-context-menu
 ```
 

--- a/lib/v3-lab.js
+++ b/lib/v3-lab.js
@@ -165,7 +165,7 @@ const Lab = window.Lab = {
       }
       input = input.trim();
       if (!input.match(/^<math/)) {
-        input = '<math>' + input;
+        input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' + input;
       }
       if (!input.match(/\/math>$/)) {
         input += '</math>';

--- a/lib/v3-lab.js
+++ b/lib/v3-lab.js
@@ -158,6 +158,21 @@ const Lab = window.Lab = {
         return math;
     },
 
+    readInput() {
+      let input = this.input.value;
+      if (this.format !== 'MathML') {
+        return input;
+      }
+      input = input.trim();
+      if (!input.match(/^<math/)) {
+        input = '<math>' + input;
+      }
+      if (!input.match(/\/math>$/)) {
+        input += '</math>';
+      }
+      return input;
+    },
+
     /**
      * Perform the typesetting of the math in the proper format
      */
@@ -175,7 +190,7 @@ const Lab = window.Lab = {
         //   set its metrics, and link it to the text element created above, then
         //   add it to the document's math list.
         //
-        this.mathItem = this.MathItem(this.input.value, this.output);
+        this.mathItem = this.MathItem(this.readInput(), this.output);
         this.doc.clear();
         this.doc.math.push(this.mathItem);
 


### PR DESCRIPTION
Update to the MathML lab:
* Trim whitespace to avoid "incorrect MathML" error, for instance, when copying content with newline.
* Check whether `math` tag needs to be added. This makes it easier to copy SRE tests directly into the lab, where `math` are generally omitted.