### PR TITLE
Update lab to include more options available in v4, and update loaders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - "stable"
-sudo: false
-branches:
-install:
-  - cd tests; npm install
-script: npm test

--- a/README.md
+++ b/README.md
@@ -1,52 +1,51 @@
-# MathJax v3 Developers Tools
+# MathJax v4 Developers Tools
 
-Some developers tools for testing local MathJax v3 code base.
+Some developers tools for testing local MathJax v4 code base.
 
 ## General setup
 
 To run most scripts in the tools you need to connect to your current version of
-MathJax3.  Assuming that MathJax3 sources are at `<MJ3-PATH>` you need to link
-in the JavaScript sources there:
+MathJax4.  To do this, `cd` to the current MathJax4 directory and do
 
 ``` shell
-ln -s <MJ3-PATH> mathjax3
+npm link
 ```
+
+then `cd` to the MathJax-dev directory and do
+
+``` shell
+npm install
+npm link mathjax-full
+```
+
 For the remainder we assume that this symlink has been set.
 
-## Getting the Lab to work
+## Running the lab
 
-
-You need to install the MathJax context menu and the mhchem parser first:
-
-``` shell
-npm install mj-context-menu
-npm install mhchemparser
-npm install speech-rule-engine
-```
-
-Then run the lab by loading `v3-lab.html` in your webbrowser via a local
+Then run the lab by loading `v4-lab.html` in your webbrowser via a local
 webserver. E.g., create a symbolic link
 
 
 ``` shell
-sudo ln -s <MathJax-dev-PATH> /var/www/html/
+sudo ln -s <MathJax-dev-PATH> /var/www/html/MathJax-dev
 ```
 
 Run the lab on `localhost` using the URL
 
 ``` shell
-http://localhost/MathJax-dev/v3-lab.html
+http://localhost/MathJax-dev/v4-lab.html
 ```
 
-Or alternatively serve directly from the directory, i.e., by running a python server:
+Or, alternatively, serve directly from the directory, e.g., by running a python server:
 
 ``` shell
 python -m SimpleHTTPServer 8000
 ```
+
 and then run the lab at the following URL
 
 ``` shell
-http://localhost:8000/v3-lab.html
+http://localhost:8000/v4-lab.html
 ```
 
 
@@ -59,23 +58,21 @@ using `node` or in a browser.
 
 ### Running Samples in Node
 
-Samples are run in `node` using the `esm` package on load. You need to first install `esm` by
-
-``` shell
-npm install esm
-```
-
-The general command to run scripts is then:
+Samples are run in `node` using a command
 
 ``` shell
 node -r esm samples/<SCRIPT>.js <INPUT>
 ```
 
-As example consider the script to parse LaTeX expressions into MathML:
+where `<SCRIPT>` is replaced by the script you want to run, and `<INPUT>` by whatever input that script may need.
+
+As example, consider the script to parse LaTeX expressions into MathML:
 
 ``` shell
-node -r esm samples/tex2mml.js x^2
+node samples/tex2mml.js 'x^2'
 ```
+
+It should print the following
 
 ``` html
 <math display="block">
@@ -91,13 +88,13 @@ node -r esm samples/tex2mml.js x^2
 Samples can be run in the browser using the `load.html` page. This either loads
 the `main.js` file or the particular sample file given in the parameters. For example, running
 
-[http://localhost/v3-dev/load.html?samples/asciimath-document.js](http://localhost/v3-dev/load.html?samples/asciimath-document.js)
+[http://localhost/MathJax-dev/load.html?samples/asciimath-document.js](http://localhost/MathJax-dev/load.html?samples/asciimath-document.js)
 
 will give you a rendered page of AsciiMath expressions in the browser. Note,
 that the output will also be displayed on the console. In fact, many scripts
 will only produce console output. For example, the URL:
 
-[http://localhost/v3-dev/load.html?samples/tex2mml.js&x^2](http://localhost/v3-dev/load.html?samples/tex2mml.js&x^2)
+[http://localhost/MathJax-dev/load.html?samples/tex2mml.js&x^2](http://localhost/MathJax-dev/load.html?samples/tex2mml.js&x^2)
 
 will print the corresponding MathML expression in the console:
 

--- a/lib/v4-lab.js
+++ b/lib/v4-lab.js
@@ -101,7 +101,7 @@ window.MathJax = {
     require: (url) => import(url)
   },
   output: {
-    fontPath: './node_modules/%%FONT%%-font/mjs'
+    fontPath: '../node_modules/%%FONT%%-font'
   },
   options: {
     compileError(doc, math, err) {console.log(err); return doc.compileError(math, err)},
@@ -150,12 +150,32 @@ const Lab = window.Lab = {
     MML: false,                                 // true when MathML output is to be shown
     secondOutput: false                         // true when second output is to be shown
   },
+  mmlincludes: {                                // MathML menu settings
+    showSRE: false,
+    showTex: false,
+    texHints: true,
+  },
   texinput: {                                   // tex input settings
     tags: 'none',
     tagSide: 'right',
-    tagIndent: '0.8em'
+    tagIndent: '0.8em',
+    mathStyle: 'TeX',
+    allowTexHTML: true
+  },
+  mmlinput: {                                   // MathML input settings
+    allowHtmlInTokenNodes: false,
+    fixMisplacedChildren: true
+  },
+  verify: {                                     // MathML verification options
+    checkArity: true,
+    checkAttributes: false,
+    checkMathvariants: true,
+    fullErrors: false,
+    fixMmultiscripts: true,
+    fixMtables: true
   },
   output: {                                     // output jax settings
+    breakInline: false,
     mathmlSpacing: false,
     mtextInheritFont: false,
     merrorInheritFont: false,
@@ -163,15 +183,18 @@ const Lab = window.Lab = {
     merrorFont: 'serif',
     displayAlign: 'center',
     displayIndent: '0',
+    displayOverflow: 'overflow',
+    htmlHDW: 'auto',
+    font: 'modern',
     fontCache: 'local',
-    adaptiveCSS: true
+    adaptiveCSS: true,
+    matchFontHeight: true
   },
   menu: {
     enrich: false,                              // true when semantic enrichment is to be performed
     compute: false,                             // true when complexity should be computed
     collapse: false,                            // true when mactions should be inserted for complex math
-    explore: false,                             // true when the explorer is enabled
-    semantics: false                            // true when data-semantics attributes should be removed
+    explore: false                              // true when the explorer is enabled
   },
   packages: {
     mml: {},                                    // the list of element ids for the MML package checkboxes
@@ -180,8 +203,11 @@ const Lab = window.Lab = {
   },
   details: {                                    // which details are open
     render: true,
+    mmlincludes: false,
     menu: true,
     texinput: false,
+    mmlinput: false,
+    verify: false,
     output: false,
     mml: false,
     tex: true,
@@ -193,19 +219,30 @@ const Lab = window.Lab = {
       format: ['TeX', 'MathML'],
       jax: ['CHTML', 'SVG']
     }],
+    ['mmlincludes', {}, 'setMmlFlag', {
+      showSRE: 'SRE attributes',
+      showTex: 'LaTeX attributes',
+      texHints: 'TeX hints'
+    }],
     'menu',
     ['texinput', {
       tags: ['none', 'ams', 'all'],
       tagSide: ['left', 'right'],
-      tagIndent: ['0em', '0.8em', '1em', '2em', '-1em']
+      tagIndent: ['0em', '0.8em', '1em', '2em', '-1em'],
+      mathStyle: ['TeX', 'ISO', 'French', 'upright'],
     }, 'setTexInput'],
+    ['mmlinput', {}, 'setMmlInput'],
+    ['verify', {}, 'setVerify'],
     ['output', {
       mtextFont: ['', 'serif', 'Arial', 'Times', 'Courier'],
       merrorFont: ['', 'serif', 'Arial', 'Times', 'Courier'],
       displayAlign: ['left', 'center', 'right'],
       displayIndent: ['-5em', '-2em', '-1em', '0', '1em', '2em', '5em'],
+      displayOverflow: ['overflow', 'scroll', 'linebreak', 'scale', 'truncate'],
+      htmlHDW: ['auto', 'ignore', 'use', 'force'],
+      font: ['asana', 'bonum', 'dejavu', 'fira', 'modern', 'pagella', 'schola', 'stix2', 'termes', 'tex'],
       fontCache: ['none', 'local', 'global']
-    }, 'setOutput'],
+    }, 'setOutput', {breakInline: 'Inline breaks'}],
     'packages',
     'details'
   ],
@@ -306,9 +343,7 @@ const Lab = window.Lab = {
     this.mathml.innerHTML = '';
     if (this.render.MML && math.root) {
       const mml = this.doc.menu.toMML(math);
-      const text = (this.menu.semantics ?
-                    mml.replace(/ (?:data-semantic-.*?|role|aria-(?:level|posinset|setsize))=".*?"/g, '') :
-                    mml.replace(/data-semantic/g, 'DS'));
+      const text = mml.replace(/data-semantic/g, 'DS');
       this.mathml.appendChild(document.createTextNode(text));
     }
   },
@@ -479,13 +514,25 @@ const Lab = window.Lab = {
    */
   newPackages() {
     if (this.render.format === 'TeX') {
-      MathJax.config.tex.packages = this.getPackages('tex');
-      if (MathJax.config.tex.packages.indexOf('textmacros') >= 0) {
-        MathJax.config.tex.textmacros = {packages: this.getPackages('text')};
+      const tex = MathJax.config.tex;
+      tex.tags = this.texinput.tags;
+      if (tex.tags === 'ams' && !this.packages.tex.ams.checked) {
+        tex.tags = this.texinput.tags = document.getElementById('tags').value = 'none';
+      }
+      tex.packages = this.getPackages('tex');
+      if (this.packages.tex.textmacros.checked) {
+        ex.textmacros = {packages: this.getPackages('text')};
         this.disablePackages('text', false);
       } else {
-        delete MathJax.config.tex.textmacros;
+        delete tex.textmacros;
         this.disablePackages('text', true);
+      }
+      if (this.packages.tex.texhtml.checked) {
+        tex.allowTexHTML = this.texinput.allowTexHTML;
+        document.getElementById('allowTexHTML').disabled = false;
+      } else {
+        document.getElementById('allowTexHTML').disabled = true;
+        delete tex.allowTexHTML;
       }
       this.newTexInput();
     }
@@ -508,7 +555,7 @@ const Lab = window.Lab = {
   newOutput() {
     const jax = (this.render.jax === 'CHTML' ?
                  new MathJax._.output.chtml_ts.CHTML(MathJax.config.chtml) :
-                 new MathJax._.output.svg_ts.SVG(MathJax.config.SVG));
+                 new MathJax._.output.svg_ts.SVG(MathJax.config.svg));
     jax.setAdaptor(this.doc.adaptor);
     this.doc.menu.jax[this.render.jax] = jax;
     this.doc.outputJax = jax;
@@ -571,7 +618,7 @@ const Lab = window.Lab = {
       this.disablePackages('text', true);
       tex = this.input.value;
       const mml = this.doc.menu.toMML(this.mathItem);
-      this.input.value = mml.replace(/ data-semantic-\S+="[^"]*"/g, '');
+      this.input.value = mml;
     }
     this.Typeset();
     this.prevTex = tex;
@@ -586,47 +633,133 @@ const Lab = window.Lab = {
     this.render.jax = value;
     document.getElementById('fontCache').disabled = (value === 'CHTML');
     document.getElementById('adaptiveCSS').disabled = (value === 'SVG');
+    document.getElementById('matchFontHeight').disabled = (value === 'SVG');
     this.setVariable('renderer', value);
+    const promises = this.doc.menu.constructor.loadingPromises;
+    const promise = promises.get('output/' + value.toLowerCase()) || Promise.resolve();
+    promise.then(() => {
+      this.newOutput();
+      this.Typeset();
+    });
   },
 
   /**
    * Set a TeX input option and retypeset
    *
-   * @param {HTMLElement} node   The input element beinbg updated
+   * @param {HTMLElement} node   The input element being updated
    */
   setTexInput(node) {
     const key = node.id;
-    const value = node.value;
+    const value = this.nodeValue(node);
     this.texinput[key] = value;
     MathJax.config.tex[key] = value;
     this.jax.TeX.parseOptions.options[key] = value;
-    if (key === 'tags') {
-      this.newTexInput();
+    if (key === 'mathStyle') {
+      this.jax.TeX.parseOptions.mathStyle = this.jax.TeX.parseOptions.constructor.getVariant.get(value);
     }
+    if (key === 'tags') {
+      if (value === 'ams' && !this.packages.tex.ams.checked) {
+        this.packages.tex.ams.checked = true;
+      }
+      this.newPackages();
+    }
+    this.Typeset();
+  },
+
+  /**
+   * Set a MathML input option and retypeset
+   *
+   * @param {HTMLElement} node   The input element being updated
+   */
+  setMmlInput(node) {
+    const key = node.id;
+    const value = this.nodeValue(node);
+    this.mmlinput[key] = value;
+    MathJax.config.mml[key] = value;
+    this.jax.MathML.mathml.options[key] = value;
+    this.Typeset();
+  },
+
+  /**
+   * Set a MathML verification option and retypeset
+   *
+   * @param {HTMLElement} node   The input element being updated
+   */
+  setVerify(node) {
+    const key = node.id;
+    const value = this.nodeValue(node);
+    this.verify[key] = value;
+    if (!MathJax.config.mml.verify) {
+      MathJax.config.mml.verify = {};
+    }
+    MathJax.config.mml.verify[key] = value;
+    this.jax.MathML.mathml.options.verify[key] = (value === 'on' || value === true);
     this.Typeset();
   },
 
   /**
    * Set an output option
    *
-   * @param {HTMLElement} node   The input element beinbg updated
+   * @param {HTMLElement} node   The input element being updated
    */
   setOutput(node) {
     const key = node.id;
-    const value = (typeof this.output[key] === 'boolean' ? node.checked : node.value);
+    const value = this.nodeValue(node);
     this.output[key] = value;
-    if (key !== 'fontCache') {
-      MathJax.config.chtml[key] = value;
+    if (key === 'font') {
+      this.setFont('mathjax-' + value);
+      return;
     }
-    if (key !== 'adaptiveCSS') {
+    if (key === 'fontCache') {
       MathJax.config.svg[key] = value;
+    } else if (key === 'adaptiveCSS' || key === 'matchFontHeight') {
+      MathJax.config.chtml[key] = value;
+    } else {
+      MathJax.config.chtml[key] = MathJax.config.svg[key] = value;
     }
-    this.doc.outputJax.options[key] = value;
-    if ((key === 'fontCache' && this.render.jax === 'SVG') ||
+    if (key === 'breakInline') {
+      this.setVariable('breakInline', value);
+    } else {
+      this.doc.outputJax.options[key] = value;
+    }
+    if (key === 'matchFontHeight') {
+      this.initMetrics();
+    }
+    if (key === 'font' ||
+        (key === 'fontCache' && this.render.jax === 'SVG') ||
         (key === 'adaptiveCSS' && this.render.jax === 'CHTML')) {
       this.newOutput();
     }
     this.Typeset();
+  },
+
+  /**
+   * Configure and load a font
+   */
+  setFont(font) {
+    MathJax.config.chtml.font = MathJax.config.svg.font = MathJax.config.output.font = font;
+    MathJax.config.loader.paths[font] = `../node_modules/${font}-font`;
+    if (MathJax._.output.chtml) {
+      MathJax.loader.load(`[${font}]/chtml`).then(() => {
+        MathJax.config.chtml.fontURL = `./node_modules/${font}-font/chtml/woff`;
+        MathJax.config.chtml.dynamicPrefix = `[${font}]/chtml/dynamic`;
+        MathJax.config.chtml.fontData = Object.values(MathJax._.output.fonts[font].chtml_ts)[0];
+        if (this.render.jax === 'CHTML') {
+          this.newOutput();
+          this.Typeset();
+        }
+      });
+    }
+    if (MathJax._.output.svg) {
+      MathJax.loader.load(`[${font}]/svg`).then(() => {
+        MathJax.config.svg.dynamicPrefix = `[${font}]/svg/dynamic`;
+        MathJax.config.svg.fontData = Object.values(MathJax._.output.fonts[font].svg_ts)[0];
+        if (this.render.jax === 'SVG') {
+          this.newOutput();
+          this.Typeset();
+        }
+      });
+    }
   },
 
   /**
@@ -722,18 +855,35 @@ const Lab = window.Lab = {
     this.setVariable('explorer', checked);
   },
 
-  setSemantics(checked) {
-    this.menu.semantics = checked;
+  /**
+   * Sets the value for one of the MAthML inclusion options
+   *
+   * @param{HTMLElement} input   The form element that is changing
+   */
+  setMmlFlag(input) {
+    this.mmlincludes[input.id] = input.checked;
+    this.setVariable(input.id, input.checked);
     this.Typeset();
   },
 
   /**
    * Loads an a11y module (complexity or explorer) if it hasn't already been loaded
+   *
+   * @param{string} component   The name of the component to load
    */
   loadA11y(component) {
     if (!MathJax._.a11y || !MathJax._.a11y[component]) {
       this.doc.menu.loadA11y(component);
     }
+  },
+
+  /**
+   * Get a node's value
+   *
+   * @param{HTMLElement} node         The node whose value is needed
+   */
+  nodeValue(node) {
+    return (node.checked !== undefined ? node.checked : node.value);
   },
 
   /*************************************************************/
@@ -743,8 +893,8 @@ const Lab = window.Lab = {
    *   for the output area and save them to be used for the MathItems during typesetting.
    */
   initMetrics() {
-    let {em, ex, containerWidth, lineWidth, scale} = MathJax.getMetricsFor(this.output1);
-    this.metrics = [em, ex, containerWidth, lineWidth, scale];
+    let {em, ex, containerWidth, scale} = MathJax.getMetricsFor(this.output1);
+    this.metrics = [em, ex, containerWidth, scale];
   },
 
   /**
@@ -755,6 +905,11 @@ const Lab = window.Lab = {
     this.setVariable('renderer', this.render.jax, true);
     this.setVariable('collapsible', this.menu.collapse, true);
     this.setVariable('explorer', this.menu.explore, true);
+    this.setVariable('showSRE', this.mmlincludes.showSRE, true);
+    this.setVariable('showTex', this.mmlincludes.showTex, true);
+    this.setVariable('texHints', this.mmlincludes.texHints, true);
+    this.setVariable('overflow', this.capitalize(this.output.displayOverflow), true);
+    this.setVariable('breakInline', this.output.breakInline, true);
 
     this.menuVariable('explorer').registerCallback(() => {
       this.menu.explore = this.doc.menu.settings.explorer;
@@ -776,12 +931,36 @@ const Lab = window.Lab = {
       }
       this.Typeset();
     });
+    this.menuVariable('semantics').registerCallback(() => this.outputMML(this.mathItem));
     this.menuVariable('renderer').registerCallback(() => {
       this.render.jax = this.doc.menu.settings.renderer;
       document.getElementById('jax').value = this.render.jax
     });
-    this.menuVariable('semantics').registerCallback(() => this.outputMML(this.mathItem));
-    this.menuVariable('texHints').registerCallback(() => this.outputMML(this.mathItem));
+    this.menuVariable('showSRE').registerCallback(() => {
+      this.mmlincludes.showSRE = this.doc.menu.options.settings.showSRE;
+      document.getElementById('showSRE').checked = this.mmlincludes.showSRE;
+      this.outputMML(this.mathItem);
+    });
+    this.menuVariable('showTex').registerCallback(() => {
+      this.mmlincludes.showTex = this.doc.menu.options.settings.showTex;
+      document.getElementById('showTex').checked = this.mmlincludes.showTex;
+      this.outputMML(this.mathItem);
+    });
+    this.menuVariable('texHints').registerCallback(() => {
+      this.mmlincludes.texHints = this.doc.menu.options.settings.texHints;
+      document.getElementById('texHints').checked = this.mmlincludes.texHints;
+      this.outputMML(this.mathItem);
+    });
+    this.menuVariable('overflow').registerCallback(() => {
+      this.output.displayOverflow = this.doc.menu.options.settings.overflow.toLowerCase();
+      document.getElementById('displayOverflow').value = this.output.displayOverflow;
+      this.Typeset();
+    });
+    this.menuVariable('breakInline').registerCallback(() => {
+      this.output.breakInline = this.doc.menu.options.settings.breakInline;
+      document.getElementById('breakInline').checked = this.output.breakInline;
+      this.Typeset();
+    });
   },
 
   /**
@@ -868,7 +1047,7 @@ const Lab = window.Lab = {
     const startup = MathJax.startup;
     startup.extendHandler(handler => this.menuHandler(handler), 20);
     //
-    // Transfer the checkbox information into the menu initialization
+    // Transfer the checkbox information into the MathJax configuration
     //
     this.initOptions();
     //
@@ -915,11 +1094,11 @@ const Lab = window.Lab = {
    */
   createFormElements() {
     for (const data of this.keepOptions) {
-      const [name, values, change] = (Array.isArray(data) ? data : [data, {}, false]);
+      const [name, values, change, labels = {}] = (Array.isArray(data) ? data : [data, {}, false]);
       if (name === 'packages') {
         Object.keys(this.packages).map(type => this.createPackageCheckboxes(type));
       } else if (change) {
-        this.createOptionElements(name, change, values);
+        this.createOptionElements(name, change, values, labels);
       }
     }
   },
@@ -930,8 +1109,9 @@ const Lab = window.Lab = {
    * @param {string} name     The name of the option collection
    * @param {string} change   The method to call when an option changes
    * @param {object} values   The object containing the option data
+   * @param {object} labels   The object containing the optional label text
    */
-  createOptionElements(name, change, values) {
+  createOptionElements(name, change, values, labels) {
     const adaptor = this.adaptor;
     const parent = document.getElementById(`${name}-details`);
     const onchange = `Lab.${change}(this)`;
@@ -940,15 +1120,16 @@ const Lab = window.Lab = {
       if (!div) {
         div = parent.appendChild(adaptor.node('div'));
       }
+      const label = labels[key] || key;
       switch(typeof value) {
       case 'boolean':
         div.appendChild(adaptor.node('input', {type: 'checkbox', id: key, onchange: onchange}));
-        div.appendChild(adaptor.node('label', {for: key}, [adaptor.text(' ' + key)]));
+        div.appendChild(adaptor.node('label', {for: key}, [adaptor.text(' ' + label)]));
         div.appendChild(adaptor.node('br'));
         break;
       case 'string':
         div = parent.appendChild(adaptor.node('div'));
-        div.appendChild(adaptor.node('label', {for: key}, [adaptor.text(key + ':')]));
+        div.appendChild(adaptor.node('label', {for: key}, [adaptor.text(label + ':')]));
         div.appendChild(adaptor.text(' '));
         const select = div.appendChild(adaptor.node('select', {id: key, onchange: onchange}));
         for (const option of values[key]) {
@@ -965,7 +1146,10 @@ const Lab = window.Lab = {
    */
   initFormElements() {
     this.setFormOptions(this.menu);
+    this.setFormOptions(this.mmlincludes);
     this.setFormOptions(this.texinput);
+    this.setFormOptions(this.mmlinput);
+    this.setFormOptions(this.verify);
     this.setFormOptions(this.output);
     this.setFormOptions(this.render);
     const format = this.render.format + (this.render.format === 'TeX' ? ' ' + (this.render.display ? 'D' : 'I') : '');
@@ -976,6 +1160,7 @@ const Lab = window.Lab = {
     this.output2.style.display = (this.render.secondOutput ? '' : 'none');
     document.getElementById('fontCache').disabled = (this.render.jax === 'CHTML');
     document.getElementById('adaptiveCSS').disabled = (this.render.jax === 'SVG');
+    document.getElementById('matchFontHeight').disabled = (this.render.jax === 'SVG');
   },
 
   /**
@@ -1001,20 +1186,77 @@ const Lab = window.Lab = {
       settings: {
         renderer: this.render.jax,
         collapsible: this.menu.collapse,
-        explorer: this.menu.explore
+        explorer: this.menu.explore,
+        showSRE: this.mmlincludes.showSRE,
+        showTex: this.mmlincludes.showTex,
+        texHints: this.mmlincludes.texHints,
+        overflow: this.capitalize(this.output.displayOverflow),
+        breakInline: this.output.breakInLine
       }
     };
+    this.initTeX();
+    this.initMathML();
+    this.initOutput();
+  },
+
+  /**
+   * Set the TeX input options
+   */
+  initTeX() {
+    const config = MathJax.config.tex;
     for (const [key, value] of Object.entries(this.texinput)) {
-      MathJax.config.tex[key] = value;
+      if (key === 'allowTexHTML' && !this.packages.tex.texhtml.checked) continue;
+      if (key === 'tags' && value === 'ams') continue;  // handled later
+      config[key] = value;
     }
+  },
+
+  /**
+   * Set the MathML input options
+   */
+  initMathML() {
+    const config = MathJax.config.mml;
+    for (const [key, value] of Object.entries(this.mmlinput)) {
+      config[key] = value;
+    }
+    if (!config.verify) config.verify = {};
+    for (const [key, value] of Object.entries(this.verify)) {
+      config.verify[key] = value;
+    }
+    const options = document.getElementById('verify-details');
+    options.parentNode.appendChild(options);
+  },
+
+  /**
+   * Set the output initial values
+   */
+  initOutput() {
+    const chtml = MathJax.config.chtml;
+    const svg = MathJax.config.svg;
     for (const [key, value] of Object.entries(this.output)) {
-      if (key !== 'fontCache') {
-        MathJax.config.chtml[key] = value;
-      }
-      if (key !== 'adaptiveCSS') {
-        MathJax.config.svg[key] = value;
+      if (key === 'breakInline') {
+        chtml.linebreaks = {inline: value};
+        svg.linebreaks = {inline: value};
+      } else {
+        if (key === 'font') {
+          this.setFont('mathjax-' + value);
+          continue;
+        }
+        if (key !== 'fontCache') {
+          chtml[key] = value;
+        }
+        if (key !== 'adaptiveCSS' && key !== 'matchFontHeight') {
+          svg[key] = value;
+        }
       }
     }
+  },
+
+  /**
+   * Capitalize a string
+   */
+  capitalize(string) {
+    return string.charAt(0).toUpperCase() + string.substring(1);
   }
 
   /*************************************************************/

--- a/load.html
+++ b/load.html
@@ -1,18 +1,34 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Testing MathJax v3 setup</title>
-<script src="lib/traceur.min.js"></script>
-<script src="lib/system.js"></script>
+<title>Testing MathJax v4 setup</title>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "./node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "./node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "./node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "./node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "./node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "./node_modules/speech-rule-engine/js/",
+    "#menu/": "./node_modules/mj-context-menu/js/",
+    "#mhchem/": "./node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "./node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "./node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "./node_modules/mathjax-full/"
+  }
+}
+</script>
 <script>
-(function () {
+PACKAGE_VERSION = "4.0.0-test";
+global = window;
+</script>
+<script type="module">
   var args = (location.search.substr(1) || 'main.js').split(/&/);
-  var argv = ['browser','load.html'].concat(args.map(x => decodeURIComponent(x)));
+  var argv = ['load.html'].concat(args.map(x => decodeURIComponent(x)));
   window.process = {argv: argv};
-  System.import(argv[2])
-    .then(function () {document.body.appendChild(document.createTextNode("Done"))})
-    .catch(function (error) {console.log(error.message)});
-})();
+  import('./' + argv[1]).then(() => document.body.appendChild(document.createTextNode("Done")))
+    .catch((error) => console.log(error.message));
 </script>
 </head>
 <body>

--- a/load.js
+++ b/load.js
@@ -1,8 +1,0 @@
-process.chdir(__dirname);
-require("./lib/system.js");
-System.nodeRequire = require;  // make this available to modules running in node for now
-System.config({map: {'traceur': './lib/traceur.min.js'}});
-
-System.import(process.argv[2] || 'main.js')
-  .then(function (mj) {mathjax = mj.MathJax})
-  .catch(function (error) {console.log(error.message)});

--- a/load.mjs
+++ b/load.mjs
@@ -1,2 +1,0 @@
-require = require("esm")(module/*, options*/)
-module.exports = require('./' + (process.argv[2] || 'main.js'));

--- a/main.js
+++ b/main.js
@@ -1,22 +1,22 @@
-import {mathjax} from './mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from './mathjax3/js/input/tex.js';
-import {RegisterHTMLHandler} from './mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from './mathjax3/js/adaptors/chooseAdaptor.js';
-import {CHTML} from './mathjax3/js/output/chtml.js';
-import {STATE} from './mathjax3/js/core/MathItem.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {CHTML} from 'mathjax-full/js/output/chtml.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
 const adaptor = chooseAdaptor();
 RegisterHTMLHandler(adaptor);
 
-const html = mathjax.document('<html></html>', {
+const html = mathjax.document('', {
   InputJax: new TeX(),
-  OutputJax: new CHTML()
+  OutputJax: new CHTML({})
 });
 
 mathjax.handleRetriesFor(() => {
 
-    let math = html.convert(process.argv[3] || '', {end: STATE.TYPESET});
+    let math = html.convert(process.argv[2] || '', {end: STATE.TYPESET});
     console.log(adaptor.outerHTML(math));
 
 }).catch(err => console.log(err.stack));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,24 @@
 {
   "name": "MathJax-dev",
+  "version": "4.0.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "MathJax-dev",
+      "version": "4.0.0-beta",
+      "license": "Apache-2.0",
       "dependencies": {
-        "mathjax-modern-font": "^1.0.0-beta.5",
+        "mathjax-asana-font": "^4.0.0-beta.4",
+        "mathjax-bonum-font": "^4.0.0-beta.4",
+        "mathjax-dejavu-font": "^4.0.0-beta.4",
+        "mathjax-fira-font": "^4.0.0-beta.4",
+        "mathjax-modern-font": "^4.0.0-beta.4",
+        "mathjax-pagella-font": "^4.0.0-beta.4",
+        "mathjax-schola-font": "^4.0.0-beta.4",
+        "mathjax-stix2-font": "^4.0.0-beta.4",
+        "mathjax-termes-font": "^4.0.0-beta.4",
+        "mathjax-tex-font": "^4.0.0-beta.4",
         "mhchemparser": "^4.2.1",
         "mj-context-menu": "^0.9.1",
         "speech-rule-engine": "^4.1.0-beta.7"
@@ -27,10 +40,55 @@
         "node": ">=14"
       }
     },
+    "node_modules/mathjax-asana-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-asana-font/-/mathjax-asana-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-RTCTOaQYKn5+PrxZegAZdbNDX3lVEP3cNLb3ssnxss3T3aQdCFoVF2I9VtQt4j7Bjhc0X4k8w/FOj72nt2/IAw=="
+    },
+    "node_modules/mathjax-bonum-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-bonum-font/-/mathjax-bonum-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-kr9fISnXfqSxcC3hP8V8QRi+aZINyfmaspLCt0ciccKgtJU+2uZ7VDa1hsxk/y1ayZdCq0keaLMOUWLttZw+lg=="
+    },
+    "node_modules/mathjax-dejavu-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-dejavu-font/-/mathjax-dejavu-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-plE53VBiPeKfnBX/CVnwUouw2WPfGTLz2W/sfKrC5fbv6obeAPa6pLUkaUGKmzmFcZ/PQirobjLHAgmdelIsdg=="
+    },
+    "node_modules/mathjax-fira-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-fira-font/-/mathjax-fira-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-RkaQlhOjSBVtM+S3RGBCB7CIRoZt0JgsqMbRPUtTzsTc1DND7yquUDuxG42V8GgxqJL6PPR2OMZPF/WwPLwP/g=="
+    },
     "node_modules/mathjax-modern-font": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/mathjax-modern-font/-/mathjax-modern-font-1.0.0-beta.5.tgz",
-      "integrity": "sha512-p3K+PgJ1cMfSo2WBxnqGVAB+DaC8Mf3MJK21WVYzFGz+suzQbT138a/SG3LUToazG8hxTVAHSd3GaMHO9JDTOw=="
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-modern-font/-/mathjax-modern-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-xYZz9/bEudc6Ire4UCFgBFqtfRpAiseh55MYHkqYSBhmaIjf5LYiveYDbCh+S+aRqkU/sMeMN+7qY7re06lEgw=="
+    },
+    "node_modules/mathjax-pagella-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-pagella-font/-/mathjax-pagella-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-CL/94jDBYkWe5Fg5rkKXXMIIB301tuX1bR8OdKt2DgYnOlBMApOKPXFqCyDz8iZcOK2cN04Am46eOTs2CJyGww=="
+    },
+    "node_modules/mathjax-schola-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-schola-font/-/mathjax-schola-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-EvBdMVIdvsMhQYnX8SbnPOBSnrSPsV2u7YXSAcHYLxeBZCWDxvU4M8Kg7z0zLTB6dl7/CS6d3plPNlKmfNlhSA=="
+    },
+    "node_modules/mathjax-stix2-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-stix2-font/-/mathjax-stix2-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-gl5qx9eKj6ngUoiq9EwNbhRYWL5Moho6y6CnuYONRusP8KNlkETUCfLYY0T90bW754MMaY4jfJklg47cV3yd7g=="
+    },
+    "node_modules/mathjax-termes-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-termes-font/-/mathjax-termes-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-yc1N6kmEtw1Pd6s/Z3DQXx4umNx/KXb+xodrYjKef4BHz7rIMGQWpL030wVzbXHn5h0yqNFE1P5kd4uDA5DaLg=="
+    },
+    "node_modules/mathjax-tex-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-tex-font/-/mathjax-tex-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-xEV98RCu5iMZd/y3GiAelm79FrM6ir7D/1J1RZZLuoxvhcdQ0IvlHQ8m047FihDZKK9fWSBg6zsIHk3RfriqyA=="
     },
     "node_modules/mhchemparser": {
       "version": "4.2.1",
@@ -72,10 +130,55 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
       "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA=="
     },
+    "mathjax-asana-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-asana-font/-/mathjax-asana-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-RTCTOaQYKn5+PrxZegAZdbNDX3lVEP3cNLb3ssnxss3T3aQdCFoVF2I9VtQt4j7Bjhc0X4k8w/FOj72nt2/IAw=="
+    },
+    "mathjax-bonum-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-bonum-font/-/mathjax-bonum-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-kr9fISnXfqSxcC3hP8V8QRi+aZINyfmaspLCt0ciccKgtJU+2uZ7VDa1hsxk/y1ayZdCq0keaLMOUWLttZw+lg=="
+    },
+    "mathjax-dejavu-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-dejavu-font/-/mathjax-dejavu-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-plE53VBiPeKfnBX/CVnwUouw2WPfGTLz2W/sfKrC5fbv6obeAPa6pLUkaUGKmzmFcZ/PQirobjLHAgmdelIsdg=="
+    },
+    "mathjax-fira-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-fira-font/-/mathjax-fira-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-RkaQlhOjSBVtM+S3RGBCB7CIRoZt0JgsqMbRPUtTzsTc1DND7yquUDuxG42V8GgxqJL6PPR2OMZPF/WwPLwP/g=="
+    },
     "mathjax-modern-font": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/mathjax-modern-font/-/mathjax-modern-font-1.0.0-beta.5.tgz",
-      "integrity": "sha512-p3K+PgJ1cMfSo2WBxnqGVAB+DaC8Mf3MJK21WVYzFGz+suzQbT138a/SG3LUToazG8hxTVAHSd3GaMHO9JDTOw=="
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-modern-font/-/mathjax-modern-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-xYZz9/bEudc6Ire4UCFgBFqtfRpAiseh55MYHkqYSBhmaIjf5LYiveYDbCh+S+aRqkU/sMeMN+7qY7re06lEgw=="
+    },
+    "mathjax-pagella-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-pagella-font/-/mathjax-pagella-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-CL/94jDBYkWe5Fg5rkKXXMIIB301tuX1bR8OdKt2DgYnOlBMApOKPXFqCyDz8iZcOK2cN04Am46eOTs2CJyGww=="
+    },
+    "mathjax-schola-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-schola-font/-/mathjax-schola-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-EvBdMVIdvsMhQYnX8SbnPOBSnrSPsV2u7YXSAcHYLxeBZCWDxvU4M8Kg7z0zLTB6dl7/CS6d3plPNlKmfNlhSA=="
+    },
+    "mathjax-stix2-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-stix2-font/-/mathjax-stix2-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-gl5qx9eKj6ngUoiq9EwNbhRYWL5Moho6y6CnuYONRusP8KNlkETUCfLYY0T90bW754MMaY4jfJklg47cV3yd7g=="
+    },
+    "mathjax-termes-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-termes-font/-/mathjax-termes-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-yc1N6kmEtw1Pd6s/Z3DQXx4umNx/KXb+xodrYjKef4BHz7rIMGQWpL030wVzbXHn5h0yqNFE1P5kd4uDA5DaLg=="
+    },
+    "mathjax-tex-font": {
+      "version": "4.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/mathjax-tex-font/-/mathjax-tex-font-4.0.0-beta.4.tgz",
+      "integrity": "sha512-xEV98RCu5iMZd/y3GiAelm79FrM6ir7D/1J1RZZLuoxvhcdQ0IvlHQ8m047FihDZKK9fWSBg6zsIHk3RfriqyA=="
     },
     "mhchemparser": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,33 @@
 {
+  "name": "MathJax-dev",
+  "version": "4.0.0-beta",
+  "description": "An interactive labe for testing MathJax from source.",
+  "keywords": [
+    "MathJax"
+  ],
+  "license": "Apache-2.0",
+  "maintainers": [
+    "MathJax, Inc. <info@mathjax.org> (http://www.mathjax.org)"
+  ],
+  "bugs": {
+    "url": "http://github.com/mathjax/MathJax/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mathjax/MathJax-dev/"
+  },
+  "type": "module",
   "dependencies": {
-    "mathjax-modern-font": "^1.0.0-beta.5",
+    "mathjax-asana-font": "^4.0.0-beta.4",
+    "mathjax-bonum-font": "^4.0.0-beta.4",
+    "mathjax-dejavu-font": "^4.0.0-beta.4",
+    "mathjax-fira-font": "^4.0.0-beta.4",
+    "mathjax-modern-font": "^4.0.0-beta.4",
+    "mathjax-pagella-font": "^4.0.0-beta.4",
+    "mathjax-schola-font": "^4.0.0-beta.4",
+    "mathjax-stix2-font": "^4.0.0-beta.4",
+    "mathjax-termes-font": "^4.0.0-beta.4",
+    "mathjax-tex-font": "^4.0.0-beta.4",
     "mhchemparser": "^4.2.1",
     "mj-context-menu": "^0.9.1",
     "speech-rule-engine": "^4.1.0-beta.7"

--- a/v4-lab.html
+++ b/v4-lab.html
@@ -10,17 +10,17 @@
 <script type="importmap">
 {
   "imports": {
-    "#js/": "./mathjax3/mjs/",
-    "#source/source.cjs": "./mathjax3/components/mjs/source-lab.js",
-    "#root/": "./mathjax3/mjs/components/mjs/",
-    "#mml3/": "./mathjax3/mjs/input/mathml/mml3/mjs/",
+    "#js/": "./node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "./node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "./node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "./node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
     "#default-font/": "./node_modules/mathjax-modern-font/mjs/",
     "#sre/": "./node_modules/speech-rule-engine/js/",
     "#menu/": "./node_modules/mj-context-menu/js/",
     "#mhchem/": "./node_modules/mhchemparser/esm/",
-    "mathjax-full/components/src/": "./mathjax3/components/mjs/",
-    "mathjax-full/js/": "./mathjax3/mjs/",
-    "mathjax-full/": "./mathjax3/"
+    "mathjax-full/components/src/": "./node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "./node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "./node_modules/mathjax-full/"
   }
 }
 </script>
@@ -92,6 +92,9 @@ body {
 #controls details > div {
   margin-bottom: .5em;
   white-space: nowrap;
+}
+#controls details details {
+  margin-left: 1em;
 }
 summary + * {
   margin-top: .5em;
@@ -175,6 +178,9 @@ input[disabled] + label {
 <input type="checkbox" id="MML" onchange="Lab.setMathML(this.checked)" /><label for="MML"> Show MathML</label><br/>
 <input type="checkbox" id="secondOutput" onchange="Lab.setSecondOutput(this.checked)" /><label for="secondOutput"> Show 2nd Output</label>
 </div>
+<details id="mmlincludes-details" ontoggle="Lab.setDetails(this)">
+<summary>MathML Includes:</summary>
+</details>
 </details>
 
 <hr/>
@@ -187,11 +193,6 @@ input[disabled] + label {
 <input type="checkbox" id="collapse" onchange="Lab.setCollapse(this.checked)" /><label for="collapse"> Collapse Complex Math</label><br/>
 <input type="checkbox" id="explore" onchange="Lab.setExplorer(this.checked)" /><label for="explore"> Math Explorer</label><br/>
 </div>
-<div>
-<input type="checkbox" id="semantics"
-onchange="Lab.setSemantics(this.checked)" /><label for="semantics">
-Hide Semantic Attributes</label><br/>
-</div>
 </details>
 </div>
 
@@ -201,14 +202,16 @@ Hide Semantic Attributes</label><br/>
 </details>
 
 <hr/>
-<details id="output-details" ontoggle="Lab.setDetails(this)">
-<summary><b>Output Options:</b></summary>
+<details id="mmlinput-details" ontoggle="Lab.setDetails(this)">
+<summary><b>MathML Input Options:</b></summary>
+<details id="verify-details" ontoggle="Lab.setDetails(this)">
+<summary>Verification Options:</summary>
+</details>
 </details>
 
 <hr/>
-<details id="mml-details" ontoggle="Lab.setDetails(this)">
-<summary><b>MathML Extensions:</b></summary>
-<div id="mml-package"></div>
+<details id="output-details" ontoggle="Lab.setDetails(this)">
+<summary><b>Output Options:</b></summary>
 </details>
 
 <hr/>
@@ -221,6 +224,12 @@ Hide Semantic Attributes</label><br/>
 <details id="text-details" ontoggle="Lab.setDetails(this)">
 <summary><b>TextMacros Packages:</b></summary>
 <div id="text-package"></div>
+</details>
+
+<hr/>
+<details id="mml-details" ontoggle="Lab.setDetails(this)">
+<summary><b>MathML Extensions:</b></summary>
+<div id="mml-package"></div>
 </details>
 
 </div>


### PR DESCRIPTION
This PR update the v4 lab to include controls for more of the options available in mathJax v4, such as the font settings, HTML-in-MathML and HTML-in-TeX controls, and MathML input options.  It also cleans up a number of problems with some of the options that could cause crashes in the past (e.g., setting the tags to "ams" and pressing "keep").

Note that this PR assumes you have merged the `menu-filters` branch in `MathJax-src`, since it relies on some of the changes there.  Also note that old URLs that include the "keep" data will no longer work, as the data has changed to accommodate the new options.

You also need to do

``` shell
npm link
```

in the MathJax-src directory, and then

``` shell
npm install
npm link mathjax-full
```

in the `MathJax-dev` directory to hook in the `mathjax-full` node_modules link.  This replaces the `mathjax3` link from earlier versions of the lab.  The README has been updated to reflect these changes.

The `package.json` has been updated to include more information, and to reflect the changes to the link above.

The `load.html` and `main.js` files have been updated to work with the v4 ESM modules.  The samples will be updated in a separate PR.