### PR TITLE
Update samples to work with v4 loaders

### DIFF
--- a/samples/asciimath-document.js
+++ b/samples/asciimath-document.js
@@ -1,9 +1,9 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {AsciiMath} from '../mathjax3/js/input/asciimath.js';
-import {CHTML} from '../mathjax3/js/output/chtml.js';
+import {AsciiMath} from 'mathjax-full/js/input/asciimath.js';
+import {CHTML} from 'mathjax-full/js/output/chtml.js';
 import {adaptor, htmlDocument} from './lib/chooseHTML.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
 const OPTIONS = {
   InputJax: new AsciiMath(),

--- a/samples/asciimath-json.js
+++ b/samples/asciimath-json.js
@@ -1,9 +1,9 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {AsciiMath} from '../mathjax3/js/input/asciimath.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {AsciiMath} from 'mathjax-full/js/input/asciimath.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
@@ -11,7 +11,7 @@ const html = mathjax.document('<html></html>', {
   InputJax: new AsciiMath()
 });
 
-import {JsonMmlVisitor} from '../mathjax3/js/core/MmlTree/JsonMmlVisitor.js';
+import {JsonMmlVisitor} from 'mathjax-full/js/core/MmlTree/JsonMmlVisitor.js';
 const visitor = new JsonMmlVisitor();
 const toJSON = (node => visitor.visitTree(node));
 

--- a/samples/asciimath2mml-component.js
+++ b/samples/asciimath2mml-component.js
@@ -3,11 +3,11 @@ global.MathJax = {
         failed: (error => console.log(`>> MathJax(${error.package || '?'}): ${error.message} ${error.stack}`)),
         load: ['adaptors/liteDOM', 'input/asciimath'],
         paths: {
-            mathjax: '../mathjax3/components/dist',
+            mathjax: 'mathjax-full/components/dist',
 //            mathjax: './components/dist',
-            sre: '../mathjax3/js/a11y/sre-node'
+            sre: 'mathjax-full/js/a11y/sre-node'
         },
-        source: require('../mathjax3/components/src/source.js').source,
+        source: require('mathjax-full/components/src/source.js').source,
 //        require: (url) => System.import(url)
         require: require
     },
@@ -25,5 +25,5 @@ global.MathJax = {
 //require('../components/src/tex-chtml/tex-chtml.js');
 
 //require('../components/dist/startup.js');
-require('../mathjax3/components/src/startup/startup.js');
+require('mathjax-full/components/src/startup/startup.js');
 

--- a/samples/asciimath2mml.js
+++ b/samples/asciimath2mml.js
@@ -1,9 +1,9 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {AsciiMath} from '../mathjax3/js/input/asciimath.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {AsciiMath} from 'mathjax-full/js/input/asciimath.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
@@ -11,7 +11,7 @@ let html = mathjax.document('<html></html>', {
   InputJax: new AsciiMath()
 });
 
-import {SerializedMmlVisitor as MmlVisitor} from '../mathjax3/js/core/MmlTree/SerializedMmlVisitor.js';
+import {SerializedMmlVisitor as MmlVisitor} from 'mathjax-full/js/core/MmlTree/SerializedMmlVisitor.js';
 let visitor = new MmlVisitor();
 let toMml = (node => visitor.visitTree(node, html.document));
 

--- a/samples/asyncLoad.js
+++ b/samples/asyncLoad.js
@@ -1,5 +1,5 @@
-import '../mathjax3/js/util/asyncLoad/node.js';
-import {asyncLoad} from '../mathjax3/js/util/AsyncLoad.js';
+import 'mathjax-full/js/util/asyncLoad/node.js';
+import {asyncLoad} from 'mathjax-full/js/util/AsyncLoad.js';
 
 asyncLoad('../js/util/entities/all.js')
     .then(() => console.log("OK"))

--- a/samples/bits.js
+++ b/samples/bits.js
@@ -1,4 +1,4 @@
-import {BitFieldClass} from '../mathjax3/js/util/BitField.js';
+import {BitFieldClass} from 'mathjax-full/js/util/BitField.js';
 
 const MyBits = BitFieldClass('test1', 'test2');
 

--- a/samples/css.js
+++ b/samples/css.js
@@ -1,6 +1,6 @@
-import {CHTML} from '../mathjax3/js/output/chtml.js';
-import {liteAdaptor} from '../mathjax3/js/adaptors/liteAdaptor.js';
-import {HTMLDocument} from '../mathjax3/js/handlers/html/HTMLDocument.js';
+import {CHTML} from 'mathjax-full/js/output/chtml.js';
+import {liteAdaptor} from 'mathjax-full/js/adaptors/liteAdaptor.js';
+import {HTMLDocument} from 'mathjax-full/js/handlers/html/HTMLDocument.js';
 
 const chtml = new CHTML();
 

--- a/samples/find-asciimath.js
+++ b/samples/find-asciimath.js
@@ -1,6 +1,6 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {AsciiMath} from '../mathjax3/js/input/asciimath.js';
+import {AsciiMath} from 'mathjax-full/js/input/asciimath.js';
 import {adaptor, htmlDocument} from './lib/chooseHTML.js';
 import {printFound} from './lib/found.js';
 

--- a/samples/find-mml.js
+++ b/samples/find-mml.js
@@ -1,6 +1,6 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {MathML} from '../mathjax3/js/input/mathml.js';
+import {MathML} from 'mathjax-full/js/input/mathml.js';
 import {htmlDocument} from './lib/chooseHTML.js';
 
 const OPTIONS = {

--- a/samples/find-strings.js
+++ b/samples/find-strings.js
@@ -1,6 +1,6 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
 import {adaptor, htmlDocument} from './lib/chooseHTML.js';
 import {printFound} from './lib/found.js';
 

--- a/samples/find-tex-dollars.js
+++ b/samples/find-tex-dollars.js
@@ -1,7 +1,7 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {APPEND} from '../mathjax3/js/util/Options.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {APPEND} from 'mathjax-full/js/util/Options.js';
 import {htmlDocument} from './lib/chooseHTML.js';
 import {printFound} from './lib/found.js';
 

--- a/samples/find-tex.js
+++ b/samples/find-tex.js
@@ -1,6 +1,6 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
 import {htmlDocument} from './lib/chooseHTML.js';
 import {printFound} from './lib/found.js';
 

--- a/samples/html-full.js
+++ b/samples/html-full.js
@@ -1,7 +1,7 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 

--- a/samples/lib/chooseHTML.js
+++ b/samples/lib/chooseHTML.js
@@ -1,7 +1,7 @@
-import {mathjax} from '../../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {RegisterHTMLHandler} from '../../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../../mathjax3/js/adaptors/chooseAdaptor.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
 
 export const adaptor = chooseAdaptor();
 

--- a/samples/lite-test.js
+++ b/samples/lite-test.js
@@ -1,0 +1,15 @@
+import {mathjax} from 'mathjax-full/js/mathjax.js';
+
+import {adaptor, htmlDocument} from './lib/chooseHTML.js';
+
+const HTML = process.argv[3] || `
+  <p id="test">abx</p>
+  <p class="fred">fred</p>
+  <p>def</p>
+  <div class="fred">div</div>
+`;
+
+const html = htmlDocument(HTML);
+
+//console.log(adaptor.elementsByClass(adaptor.body(html.document), 'fred'));
+console.log(adaptor.getElements(['.fred'], html.document));

--- a/samples/mfenced.js
+++ b/samples/mfenced.js
@@ -1,9 +1,9 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {MathML} from '../mathjax3/js/input/mathml.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {MathML} from 'mathjax-full/js/input/mathml.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 

--- a/samples/mml-bbox.js
+++ b/samples/mml-bbox.js
@@ -1,10 +1,10 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {MathML} from '../mathjax3/js/input/mathml.js';
-import {CHTML} from '../mathjax3/js/output/chtml.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {MathML} from 'mathjax-full/js/input/mathml.js';
+import {CHTML} from 'mathjax-full/js/output/chtml.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
 const adaptor = chooseAdaptor();
 RegisterHTMLHandler(adaptor);

--- a/samples/mml-doc.js-orig
+++ b/samples/mml-doc.js-orig
@@ -1,10 +1,10 @@
-import {mathjax} from '../mathjax3/mathjax.js';
+import {mathjax} from 'mathjax-full/mathjax.js';
 
-import {MathML} from '../mathjax3/input/mathml.js';
-//import {CHTML} from '../mathjax3/output/chtml.js';
-import {SVG} from '../mathjax3/output/svg.js';
-import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
-import {browserAdaptor} from '../mathjax3/adaptors/browserAdaptor.js';
+import {MathML} from 'mathjax-full/input/mathml.js';
+//import {CHTML} from 'mathjax-full/output/chtml.js';
+import {SVG} from 'mathjax-full/output/svg.js';
+import {RegisterHTMLHandler} from 'mathjax-full/handlers/html.js';
+import {browserAdaptor} from 'mathjax-full/adaptors/browserAdaptor.js';
 
 RegisterHTMLHandler(browserAdaptor());
 

--- a/samples/mml-nodes.js
+++ b/samples/mml-nodes.js
@@ -1,9 +1,9 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {MathML} from '../mathjax3/js/input/mathml.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {MathML} from 'mathjax-full/js/input/mathml.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
@@ -11,7 +11,7 @@ let html = mathjax.document('<html></html>', {
   InputJax: new MathML()
 });
 
-import {TestMmlVisitor as MmlVisitor} from '../mathjax3/js/core/MmlTree/TestMmlVisitor.js';
+import {TestMmlVisitor as MmlVisitor} from 'mathjax-full/js/core/MmlTree/TestMmlVisitor.js';
 let visitor = new MmlVisitor();
 let toMathML = (node => visitor.visitTree(node, html.document));
 

--- a/samples/mml2html.js
+++ b/samples/mml2html.js
@@ -1,10 +1,10 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {MathML} from '../mathjax3/js/input/mathml.js';
-import {CHTML} from '../mathjax3/js/output/chtml.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {MathML} from 'mathjax-full/js/input/mathml.js';
+import {CHTML} from 'mathjax-full/js/output/chtml.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
 const adaptor = chooseAdaptor();
 RegisterHTMLHandler(adaptor);

--- a/samples/mml2svg.js
+++ b/samples/mml2svg.js
@@ -1,10 +1,10 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {MathML} from '../mathjax3/js/input/mathml.js';
-import {SVG} from '../mathjax3/js/output/svg.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {MathML} from 'mathjax-full/js/input/mathml.js';
+import {SVG} from 'mathjax-full/js/output/svg.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
 const adaptor = chooseAdaptor();
 RegisterHTMLHandler(adaptor);

--- a/samples/notagids.js
+++ b/samples/notagids.js
@@ -1,12 +1,12 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {AllPackages} from '../mathjax3/js/input/tex/AllPackages.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {AllPackages} from 'mathjax-full/js/input/tex/AllPackages.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
-import {AbstractTags, TagsFactory} from '../mathjax3/js/input/tex/Tags.js';
+import {AbstractTags, TagsFactory} from 'mathjax-full/js/input/tex/Tags.js';
 
 class NoIdTags extends AbstractTags {
 
@@ -30,7 +30,7 @@ let html = mathjax.document(
   '',
   {InputJax: new TeX({packages: {'[-]': ['bussproofs']}, tags: 'noID'})});
 
-import {SerializedMmlVisitor} from '../mathjax3/js/core/MmlTree/SerializedMmlVisitor.js';
+import {SerializedMmlVisitor} from 'mathjax-full/js/core/MmlTree/SerializedMmlVisitor.js';
 let visitor = new SerializedMmlVisitor();
 let toMml = (node => visitor.visitTree(node));
 

--- a/samples/tables/lib/dual-tables.js
+++ b/samples/tables/lib/dual-tables.js
@@ -1,14 +1,14 @@
-import {MathML} from "../../../mathjax3/input/mathml.js";
-import {CHTML} from "../../../mathjax3/output/chtml.js";
-import {SVG} from "../../../mathjax3/output/svg.js";
-import {HTMLMathItem} from "../../../mathjax3/handlers/html/HTMLMathItem.js";
-import {HTMLDocument} from "../../../mathjax3/handlers/html/HTMLDocument.js";
-import {handleRetriesFor} from "../../../mathjax3/util/Retries.js";
-import {browserAdaptor} from "../../../mathjax3/adaptors/browserAdaptor.js";
+import {MathML} from "mathjax-full/js/input/mathml.js";
+import {CHTML} from "mathjax-full/js/output/chtml.js";
+import {SVG} from "mathjax-full/js/output/svg.js";
+import {HTMLMathItem} from "mathjax-full/js/handlers/html/HTMLMathItem.js";
+import {HTMLDocument} from "mathjax-full/js/handlers/html/HTMLDocument.js";
+import {handleRetriesFor} from "mathjax-full/js/util/Retries.js";
+import {browserAdaptor} from "mathjax-full/js/adaptors/browserAdaptor.js";
 
 let mml = new MathML({forceReparse: true});
-let chtml = new CHTML({fontURL: '../../mathjax2/css/'});
-let svg = new SVG();
+let chtml = new CHTML({fontURL: '../../node_modules/mathjax-modern-font/chtml/woff'});
+let svg = new SVG({});
 
 let docs = {
   CHTML: new HTMLDocument(document, browserAdaptor(), {InputJax: mml, OutputJax: chtml}),
@@ -75,7 +75,7 @@ function linkTables(n, m, arrow) {
     return '<a href="tables-' + N + '.html"' + (n === m ? ' disabled="true"' : '') + '>&#x' + arrow + ';</a>';
 }
 
-const testNo = parseInt(this.location.pathname.match(/-(\d+)\.html$/)[1]);
+const testNo = parseInt(window.location.pathname.match(/-(\d+)\.html$/)[1]);
 const maxTest = 60;
 
 const nav = document.body.appendChild(document.createElement('div'));
@@ -86,16 +86,9 @@ nav.innerHTML = [
 ].join(' ');
 
 
-docs.CHTML
-  .findMath({elements: ['mjx-chtml-table']})
-  .compile()
-  .getMetrics()
-  .typeset()
-  .updateDocument();
+chtml.options.elements = ['mjx-chtml-table'];
+svg.options.elements = ['mjx-svg-table'];
 
-docs.SVG
-  .findMath({elements: ['mjx-svg-table']})
-  .compile()
-  .getMetrics()
-  .typeset()
-  .updateDocument();
+docs.CHTML.render();
+docs.SVG.render();
+

--- a/samples/tables/tables-01.html
+++ b/samples/tables/tables-01.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 01</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -28,10 +43,8 @@ var variables = [
 ];
 </script>
 
-<script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+<script type="module">
+import('./lib/dual-tables.js').catch(function (error) {console.log(error)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-02.html
+++ b/samples/tables/tables-02.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 02</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -31,9 +46,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-03.html
+++ b/samples/tables/tables-03.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 03</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -29,9 +44,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-04.html
+++ b/samples/tables/tables-04.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 04</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -31,9 +46,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-05.html
+++ b/samples/tables/tables-05.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 05</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 <style>
 mjx-tables {
   width: 50%;
@@ -38,9 +53,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-06.html
+++ b/samples/tables/tables-06.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 06</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 <style>
 mjx-tables {
   width: 50%;
@@ -38,9 +53,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-07.html
+++ b/samples/tables/tables-07.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 07</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 <style>
 mjx-tables {
   width: 50%;
@@ -40,9 +55,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-08.html
+++ b/samples/tables/tables-08.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 08</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -36,9 +51,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-09.html
+++ b/samples/tables/tables-09.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 09</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -38,9 +53,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-10.html
+++ b/samples/tables/tables-10.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 10</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -36,9 +51,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-11.html
+++ b/samples/tables/tables-11.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 11</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -38,9 +53,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-12.html
+++ b/samples/tables/tables-12.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 12</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -36,9 +51,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-13.html
+++ b/samples/tables/tables-13.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 13</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -38,9 +53,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-14.html
+++ b/samples/tables/tables-14.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 14</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -36,9 +51,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-15.html
+++ b/samples/tables/tables-15.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 15</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -38,9 +53,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-16.html
+++ b/samples/tables/tables-16.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 16</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -36,9 +51,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-17.html
+++ b/samples/tables/tables-17.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 17</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -38,9 +53,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-18.html
+++ b/samples/tables/tables-18.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 18</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -36,9 +51,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-19.html
+++ b/samples/tables/tables-19.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 19</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -38,9 +53,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-20.html
+++ b/samples/tables/tables-20.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 20</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -36,9 +51,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-21.html
+++ b/samples/tables/tables-21.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 21</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -38,9 +53,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-22.html
+++ b/samples/tables/tables-22.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 22</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -36,9 +51,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-23.html
+++ b/samples/tables/tables-23.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 23</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -38,9 +53,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-24.html
+++ b/samples/tables/tables-24.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 24</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -39,9 +54,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-25.html
+++ b/samples/tables/tables-25.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 25</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -41,9 +56,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-26.html
+++ b/samples/tables/tables-26.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 26</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -39,9 +54,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-27.html
+++ b/samples/tables/tables-27.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 27</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -41,9 +56,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-28.html
+++ b/samples/tables/tables-28.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 28</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -39,9 +54,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-29.html
+++ b/samples/tables/tables-29.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 29</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -41,9 +56,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-30.html
+++ b/samples/tables/tables-30.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 30</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -39,9 +54,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-31.html
+++ b/samples/tables/tables-31.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 31</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -41,9 +56,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-32.html
+++ b/samples/tables/tables-32.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 32</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -39,9 +54,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-33.html
+++ b/samples/tables/tables-33.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 33</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -41,9 +56,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-34.html
+++ b/samples/tables/tables-34.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 34</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -39,9 +54,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-35.html
+++ b/samples/tables/tables-35.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 35</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -41,9 +56,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-36.html
+++ b/samples/tables/tables-36.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 36</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -39,9 +54,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-37.html
+++ b/samples/tables/tables-37.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 37</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -41,9 +56,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-38.html
+++ b/samples/tables/tables-38.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 38</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -39,9 +54,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-39.html
+++ b/samples/tables/tables-39.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 39</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -41,9 +56,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-40.html
+++ b/samples/tables/tables-40.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 40</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -39,9 +54,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-41.html
+++ b/samples/tables/tables-41.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 41</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -31,9 +46,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-42.html
+++ b/samples/tables/tables-42.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 42</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -33,9 +48,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-43.html
+++ b/samples/tables/tables-43.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 43</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -31,9 +46,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-44.html
+++ b/samples/tables/tables-44.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 44</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -33,9 +48,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-45.html
+++ b/samples/tables/tables-45.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 45</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 <style>
 mjx-tables {
   width: 50%;
@@ -42,9 +57,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-46.html
+++ b/samples/tables/tables-46.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 46</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -32,9 +47,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-47.html
+++ b/samples/tables/tables-47.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 47</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -34,9 +49,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-48.html
+++ b/samples/tables/tables-48.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 48</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -32,9 +47,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-49.html
+++ b/samples/tables/tables-49.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 49</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -34,9 +49,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-50.html
+++ b/samples/tables/tables-50.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 50</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 <style>
 mjx-tables {
   width: 50%;
@@ -43,9 +58,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-51.html
+++ b/samples/tables/tables-51.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 51</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -32,9 +47,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-52.html
+++ b/samples/tables/tables-52.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 52</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -34,9 +49,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-53.html
+++ b/samples/tables/tables-53.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 53</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -32,9 +47,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-54.html
+++ b/samples/tables/tables-54.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 54</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -34,9 +49,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-55.html
+++ b/samples/tables/tables-55.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 55</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 <style>
 mjx-tables {
   width: 50%;
@@ -43,9 +58,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-56.html
+++ b/samples/tables/tables-56.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 56</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -32,9 +47,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-57.html
+++ b/samples/tables/tables-57.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 57</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -34,9 +49,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-58.html
+++ b/samples/tables/tables-58.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 58</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -32,9 +47,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-59.html
+++ b/samples/tables/tables-59.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 59</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 </head>
 <body>
 
@@ -34,9 +49,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tables/tables-60.html
+++ b/samples/tables/tables-60.html
@@ -3,8 +3,23 @@
 <head>
 <title>MathJax v3 Tables Sample 60</title>
 <link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
-<script src="../../lib/traceur.min.js"></script>
-<script src="../../lib/system.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "#js/": "../../node_modules/mathjax-full/mjs/",
+    "#source/source.cjs": "../../node_modules/mathjax-full/components/mjs/source-lab.js",
+    "#root/": "../../node_modules/mathjax-full/mjs/components/mjs/",
+    "#mml3/": "../../node_modules/mathjax-full/mjs/input/mathml/mml3/mjs/",
+    "#default-font/": "../../node_modules/mathjax-modern-font/mjs/",
+    "#sre/": "../../node_modules/speech-rule-engine/js/",
+    "#menu/": "../../node_modules/mj-context-menu/js/",
+    "#mhchem/": "../../node_modules/mhchemparser/esm/",
+    "mathjax-full/components/src/": "../../node_modules/mathjax-full/components/mjs/",
+    "mathjax-full/js/": "../../node_modules/mathjax-full/mjs/",
+    "mathjax-full/": "../../node_modules/mathjax-full/"
+  }
+}
+</script>
 <style>
 mjx-tables {
   width: 50%;
@@ -43,9 +58,7 @@ var variables = [
 </script>
 
 <script>
-System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
 </script>
 </body>
 </html>
-
-

--- a/samples/tag-format.js
+++ b/samples/tag-format.js
@@ -1,12 +1,12 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
-import '../mathjax3/js/input/tex/ams/AmsConfiguration.js';
-import '../mathjax3/js/input/tex/tag_format/TagFormatConfiguration.js';
+import 'mathjax-full/js/input/tex/ams/AmsConfiguration.js';
+import 'mathjax-full/js/input/tex/tag_format/TagFormatConfiguration.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
@@ -23,7 +23,7 @@ let html = mathjax.document('', {
     })
 });
 
-import {SerializedMmlVisitor} from '../mathjax3/js/core/MmlTree/SerializedMmlVisitor.js';
+import {SerializedMmlVisitor} from 'mathjax-full/js/core/MmlTree/SerializedMmlVisitor.js';
 let visitor = new SerializedMmlVisitor();
 let toMml = (node => visitor.visitTree(node));
 

--- a/samples/test-adaptor.js
+++ b/samples/test-adaptor.js
@@ -1,5 +1,5 @@
-import {liteAdaptor} from '../mathjax3/js/adaptors/liteAdaptor.js';
-import {jsdomAdaptor} from '../mathjax3/js/adaptors/jsdomAdaptor.js';
+import {liteAdaptor} from 'mathjax-full/js/adaptors/liteAdaptor.js';
+import {jsdomAdaptor} from 'mathjax-full/js/adaptors/jsdomAdaptor.js';
 
 let JSDOM = require('jsdom').JSDOM;
 

--- a/samples/test-styles.js
+++ b/samples/test-styles.js
@@ -1,4 +1,4 @@
-import {Styles} from '../mathjax3/js/util/Styles.js';
+import {Styles} from 'mathjax-full/js/util/Styles.js';
 
 let JSDOM = require('jsdom').JSDOM;
 

--- a/samples/tex-doc.js-orig
+++ b/samples/tex-doc.js-orig
@@ -1,12 +1,12 @@
-import {mathjax} from '../mathjax3/mathjax.js';
+import {mathjax} from 'mathjax-full/mathjax.js';
 
-import {TeX} from '../mathjax3/input/tex.js';
-import {CHTML} from '../mathjax3/output/chtml.js';
-//import {SVG} from '../mathjax3/output/svg.js';
-import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
-import {browserAdaptor} from '../mathjax3/adaptors/browserAdaptor.js';
+import {TeX} from 'mathjax-full/input/tex.js';
+import {CHTML} from 'mathjax-full/output/chtml.js';
+//import {SVG} from 'mathjax-full/output/svg.js';
+import {RegisterHTMLHandler} from 'mathjax-full/handlers/html.js';
+import {browserAdaptor} from 'mathjax-full/adaptors/browserAdaptor.js';
 
-import {AllPackages} from '../mathjax3/input/tex/AllPackages.js';
+import {AllPackages} from 'mathjax-full/input/tex/AllPackages.js';
 
 const packages = AllPackages.filter(name => name !== 'noerrors');
 
@@ -31,5 +31,5 @@ mathjax.handleRetriesFor(() => {
 
 }).catch(err => console.log(err.stack));
 
-import {Package} from '../mathjax3/components/package.js';
+import {Package} from 'mathjax-full/components/package.js';
 console.log(Package.packages);

--- a/samples/tex-document.js
+++ b/samples/tex-document.js
@@ -1,7 +1,7 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {CHTML} from '../mathjax3/js/output/chtml.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {CHTML} from 'mathjax-full/js/output/chtml.js';
 import {adaptor, htmlDocument} from './lib/chooseHTML.js';
 
 const OPTIONS = {

--- a/samples/tex-json.js
+++ b/samples/tex-json.js
@@ -1,12 +1,12 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
-import {AllPackages} from '../mathjax3/js/input/tex/AllPackages.js';
-import {CHTML} from '../mathjax3/js/output/chtml.js';
-import '../mathjax3/js/input/tex/physics/PhysicsConfiguration.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
+import {AllPackages} from 'mathjax-full/js/input/tex/AllPackages.js';
+import {CHTML} from 'mathjax-full/js/output/chtml.js';
+import 'mathjax-full/js/input/tex/physics/PhysicsConfiguration.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
@@ -15,7 +15,7 @@ let html = mathjax.document('<html></html>', {
   OutputJax: new CHTML()
 });
 
-import {JsonMmlVisitor} from '../mathjax3/js/core/MmlTree/JsonMmlVisitor.js';
+import {JsonMmlVisitor} from 'mathjax-full/js/core/MmlTree/JsonMmlVisitor.js';
 let visitor = new JsonMmlVisitor();
 let toJSON = (node => visitor.visitTree(node));
 

--- a/samples/tex-multi-document.js
+++ b/samples/tex-multi-document.js
@@ -1,7 +1,7 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {CHTML} from '../mathjax3/js/output/chtml.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {CHTML} from 'mathjax-full/js/output/chtml.js';
 import {adaptor, htmlDocument} from './lib/chooseHTML.js';
 
 const OPTIONS = {

--- a/samples/tex-nodes.js
+++ b/samples/tex-nodes.js
@@ -1,9 +1,9 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
@@ -11,7 +11,7 @@ let html = mathjax.document('<html></html>',{
   InputJax: new TeX()
 });
 
-import {TestMmlVisitor} from '../mathjax3/js/core/MmlTree/TestMmlVisitor.js';
+import {TestMmlVisitor} from 'mathjax-full/js/core/MmlTree/TestMmlVisitor.js';
 let visitor = new TestMmlVisitor();
 let toMathML = (node => visitor.visitTree(node, html.document));
 

--- a/samples/tex-string.js
+++ b/samples/tex-string.js
@@ -1,9 +1,9 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 

--- a/samples/tex2html.js
+++ b/samples/tex2html.js
@@ -1,10 +1,10 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {CHTML} from '../mathjax3/js/output/chtml.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {CHTML} from 'mathjax-full/js/output/chtml.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
 const adaptor = chooseAdaptor();
 RegisterHTMLHandler(adaptor);

--- a/samples/tex2mml-component.js
+++ b/samples/tex2mml-component.js
@@ -3,10 +3,10 @@ global.MathJax = {
         failed: (error => console.log(`>> MathJax(${error.package || '?'}): ${error.message} ${error.stack}`)),
         load: ['adaptors/liteDOM', 'input/tex', /*'a11y/semantic-enrich'*/ '[tex]/tagFormat'],
         paths: {
-            mathjax: '../mathjax3/es5',
-            sre: '../mathjax3/js/a11y/sre-node'
+            mathjax: 'mathjax-full/es5',
+            sre: 'mathjax-full/js/a11y/sre-node'
         },
-        source: require('../mathjax3/components/src/source.js').source,
+        source: require('mathjax-full/components/src/source.js').source,
         require: require
     },
     tex: {
@@ -35,5 +35,5 @@ global.MathJax = {
 //require('../components/src/tex-chtml/tex-chtml.js');
 
 //require('../components/dist/startup.js');
-require('../mathjax3/components/src/startup/startup.js');
+require('mathjax-full/components/src/startup/startup.js');
 

--- a/samples/tex2mml-require.js
+++ b/samples/tex2mml-require.js
@@ -1,15 +1,15 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {APPEND} from '../mathjax3/js/util/Options.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {APPEND} from 'mathjax-full/js/util/Options.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
-import '../mathjax3/js/input/tex/base/BaseConfiguration.js';
-import '../mathjax3/js/input/tex/require/RequireConfiguration.js';
-import '../mathjax3/js/input/tex/config_macros/ConfigMacrosConfiguration.js';
-import '../mathjax3/js/input/tex/autoload/AutoloadConfiguration.js';
+import 'mathjax-full/js/input/tex/base/BaseConfiguration.js';
+import 'mathjax-full/js/input/tex/require/RequireConfiguration.js';
+import 'mathjax-full/js/input/tex/config_macros/ConfigMacrosConfiguration.js';
+import 'mathjax-full/js/input/tex/autoload/AutoloadConfiguration.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
@@ -23,7 +23,7 @@ let html = mathjax.document('<html></html>', {
     })
 });
 
-import {SerializedMmlVisitor} from '../mathjax3/js/core/MmlTree/SerializedMmlVisitor.js';
+import {SerializedMmlVisitor} from 'mathjax-full/js/core/MmlTree/SerializedMmlVisitor.js';
 let visitor = new SerializedMmlVisitor();
 let toMml = (node => visitor.visitTree(node));
 

--- a/samples/tex2mml-speech.js
+++ b/samples/tex2mml-speech.js
@@ -1,14 +1,14 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
-import '../mathjax3/js/util/asyncLoad/node.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
+import 'mathjax-full/js/util/asyncLoad/node.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {MathML} from '../mathjax3/js/input/mathml.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {EnrichHandler} from '../mathjax3/js/a11y/semantic-enrich.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
-import {AllPackages} from '../mathjax3/js/input/tex/AllPackages.js';
-import {CHTML} from '../mathjax3/js/output/chtml.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {MathML} from 'mathjax-full/js/input/mathml.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {EnrichHandler} from 'mathjax-full/js/a11y/semantic-enrich.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
+import {AllPackages} from 'mathjax-full/js/input/tex/AllPackages.js';
+import {CHTML} from 'mathjax-full/js/output/chtml.js';
 
 EnrichHandler(RegisterHTMLHandler(chooseAdaptor()), new MathML());
 
@@ -18,7 +18,7 @@ let html = mathjax.document('<html></html>', {
   OutputJax: new CHTML()   // Needed for bussproofs
 });
 
-import {SerializedMmlVisitor as MmlVisitor} from '../mathjax3/js/core/MmlTree/SerializedMmlVisitor.js';
+import {SerializedMmlVisitor as MmlVisitor} from 'mathjax-full/js/core/MmlTree/SerializedMmlVisitor.js';
 let visitor = new MmlVisitor();
 let toMml = (node => visitor.visitTree(node, html.document));
 

--- a/samples/tex2mml.js
+++ b/samples/tex2mml.js
@@ -1,20 +1,20 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
-import {AllPackages} from '../mathjax3/js/input/tex/AllPackages.js';
-import {CHTML} from '../mathjax3/js/output/chtml.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
+import {AllPackages} from 'mathjax-full/js/input/tex/AllPackages.js';
+import {CHTML} from 'mathjax-full/js/output/chtml.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
 let html = mathjax.document('<html></html>', {
   InputJax: new TeX({packages: AllPackages}),
-  OutputJax: new CHTML()
+  OutputJax: new CHTML({})
 });
 
-import {SerializedMmlVisitor as MmlVisitor} from '../mathjax3/js/core/MmlTree/SerializedMmlVisitor.js';
+import {SerializedMmlVisitor as MmlVisitor} from 'mathjax-full/js/core/MmlTree/SerializedMmlVisitor.js';
 let visitor = new MmlVisitor();
 let toMml = (node => visitor.visitTree(node, html.document));
 

--- a/samples/tex2svg-speech.js
+++ b/samples/tex2svg-speech.js
@@ -1,14 +1,14 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
-import '../mathjax3/js/util/asyncLoad/node.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
+import 'mathjax-full/js/util/asyncLoad/node.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {MathML} from '../mathjax3/js/input/mathml.js';
-import {SVG} from '../mathjax3/js/output/svg.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
-import {AllPackages} from '../mathjax3/js/input/tex/AllPackages.js';
-import {EnrichHandler} from '../mathjax3/js/a11y/semantic-enrich.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {MathML} from 'mathjax-full/js/input/mathml.js';
+import {SVG} from 'mathjax-full/js/output/svg.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
+import {AllPackages} from 'mathjax-full/js/input/tex/AllPackages.js';
+import {EnrichHandler} from 'mathjax-full/js/a11y/semantic-enrich.js';
 
 const adaptor = chooseAdaptor();
 EnrichHandler(RegisterHTMLHandler(adaptor), new MathML());

--- a/samples/tex2svg.js
+++ b/samples/tex2svg.js
@@ -1,10 +1,10 @@
-import {mathjax} from '../mathjax3/js/mathjax.js';
+import {mathjax} from 'mathjax-full/js/mathjax.js';
 
-import {TeX} from '../mathjax3/js/input/tex.js';
-import {SVG} from '../mathjax3/js/output/svg.js';
-import {RegisterHTMLHandler} from '../mathjax3/js/handlers/html.js';
-import {chooseAdaptor} from '../mathjax3/js/adaptors/chooseAdaptor.js';
-import {STATE} from '../mathjax3/js/core/MathItem.js';
+import {TeX} from 'mathjax-full/js/input/tex.js';
+import {SVG} from 'mathjax-full/js/output/svg.js';
+import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html.js';
+import {chooseAdaptor} from 'mathjax-full/js/adaptors/chooseAdaptor.js';
+import {STATE} from 'mathjax-full/js/core/MathItem.js';
 
 const adaptor = chooseAdaptor();
 RegisterHTMLHandler(adaptor);


### PR DESCRIPTION
This PR just fixes the import references in the files in the sample directory.  There are lots of files, but they all needed to be updated.  I didn't hand check that they all work, and a couple have `require()` commands that won't work, but they are really not used anymore, so I don't think it matters.  The table tests are useful, though.  They probably don't need all the pseudo-package names defined, but I didn't bother to try to trim it down.